### PR TITLE
Technical Pages

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -4,6 +4,7 @@ import defineVersionedConfig from 'vitepress-versioning-plugin'
 
 import RootSidebar from './sidebars/root'
 import PlayersSidebar from './sidebars/players'
+import TechnicalSidebar from './sidebars/technical'
 
 import { applySEO } from './seo'
 import { removeVersionedItems } from "./seo"
@@ -57,7 +58,8 @@ export default defineVersionedConfig(__dirname, {
 
     sidebar: {
       '/': RootSidebar,
-      '/players/': PlayersSidebar
+      '/players/': PlayersSidebar,
+      '/technical/': TechnicalSidebar
     },
 
     socialLinks: [

--- a/.vitepress/sidebars/root.ts
+++ b/.vitepress/sidebars/root.ts
@@ -18,5 +18,23 @@ export default [
         link: "/players/troubleshooting/uploading-logs"
       }
     ]
+  },
+  {
+    text: "Technical Info and Specs",
+    link: "/technical",
+    items: [
+      {
+        text: "fabric.mod.json Specification",
+        link: "/technical/specifications/fabric-mod-json"
+      },
+      {
+        text: "Fabric Loader",
+        link: "/technical/fabric-loader"
+      },
+      {
+        text: "Fabric Loom",
+        link: "/technical/fabric-loom"
+      }
+    ]
   }
 ] as DefaultTheme.SidebarItem[];

--- a/.vitepress/sidebars/technical.ts
+++ b/.vitepress/sidebars/technical.ts
@@ -1,0 +1,52 @@
+import { DefaultTheme } from "vitepress"
+
+export default [
+  {
+    text: "Technical Information",
+    link: "/technical/",
+    items: [
+      {
+        text: "Fabric Loader",
+        link: "/technical/fabric-loader"
+      },
+      {
+        text: "Fabric Loom",
+        link: "/technical/fabric-loom"
+      },
+      {
+        text: "Yarn",
+        link: "/technical/yarn"
+      },
+      {
+        text: "Entrypoints",
+        link: "/technical/entrypoints"
+      },
+    ]
+  },
+  {
+    text: 'Specifications',
+    items: [
+      {
+        text: 'fabric.mod.json',
+        link: '/technical/specifications/fabric-mod-json'
+      },
+      {
+        text: 'Mapping Formats',
+        items: [
+          {
+            text: 'Enigma',
+            link: '/technical/specifications/enigma'
+          },
+          {
+            text: 'Tiny v1',
+            link: '/technical/specifications/tiny/v1'
+          },
+          {
+            text: 'Tiny v2',
+            link: '/technical/specifications/tiny/v2'
+          }
+        ]
+      }
+    ]
+  },
+] as DefaultTheme.SidebarItem[];

--- a/technical/entrypoints.md
+++ b/technical/entrypoints.md
@@ -1,0 +1,189 @@
+---
+title: Entrypoints
+description: Technical information about Fabric Loader's Entrypoints system.
+---
+
+# Entrypoints
+
+Entrypoints are declared in a mod's
+[fabric.mod.json](../specifications/fabric-mod-json.md) to expose parts of the
+code for usage by Fabric Loader or other mods. They are primarily used
+to make some code run during game initialization to initialize mods,
+though the entrypoint system has other uses as well. Entrypoints are
+loaded by language adapters, which will attempt to produce a Java object
+of a specified type using the name of the code object.
+
+An entrypoint is exposed under some name, refers to some code object and
+must be based on a familiar **entrypoint prototype**. An entrypoint
+prototype defines the name (such as "main" or "client") and the expected
+type of object that the entrypoint should refer to (such as the
+`ModInitializer` interface). An **entrypoint prototype provider**
+declares an entrypoint prototype and is responsible for accessing
+entrypoints, and can state how the they will be used. Fabric Loader
+provides some built-in entrypoint prototypes, while mods can also
+provide their own.
+
+Entrypoints can be considered a more powerful implementation of [Java
+Service Provider Interfaces](https://www.baeldung.com/java-spi).
+
+### Basic usage
+
+A mod can declare any amount of entrypoints under different names in
+their fabric.mod.json. "main" is used to initialize the parts of a mod
+that are common to both a Minecraft client and a dedicated server, such
+as registry entries. "client" is used to initialize the parts of a mod
+that are reserved for clients only, such as registration of
+rendering-related objects.
+
+``` javascript
+{
+  [...]
+  "entrypoints": {
+    "main": [
+      "net.fabricmc.ExampleMod"
+    ],
+    "client": [
+      "net.fabricmc.ExampleClientMod"
+    ]
+  }
+  [...]
+}
+```
+
+**Caution:** It is recommended to use separate classes for main, client
+and server entrypoints to avoid class loading issues. Consider the case
+where the same class is used for both a main and a client entrypoint.
+When launched on a dedicated server, even if the "client" entrypoint is
+never loaded, the class that contains the client initialization logic
+will be. Even if the client logic will never be executed, the act of
+merely loading the code may trigger class loading issues.
+
+### Built-in entrypoint prototypes
+
+Fabric Loader provides four built-in entrypoint prototypes for mod
+initialization, some of which are designed to deal with initialization
+with respect to physical sides (see [side](/tutorial/side)). The main,
+client and server entrypoints are loaded and called early during the
+game's initialization, at a point where **most but not all** game
+systems are ready for modification. These entrypoints are typically used
+to bootstrap mods by registering registry objects, event listeners and
+other callbacks for doing things later.
+
+-   **main**: The first normal initialization entrypoint to run. Uses
+    the type `ModInitializer` and will call `onInitialize`.
+-   **client**: Will run after main only in a physical client. Uses the
+    type `ClientModInitializer` and will call `onInitializeClient`.
+-   **server**: Will run after main only in a physical server. Uses the
+    type `DedicatedServerModInitializer` and will call
+    `onInitializeServer`.
+-   **preLaunch (not recommended for general use)**: The earliest
+    possible entrypoint, which is called just before the game launches.
+    Use with caution to not interfere with the game's initialization.
+    Uses the type `PreLaunchEntryPoint` and will call `onPreLaunch`.
+
+All main entrypoints are called before all client/server entrypoints.
+The exact time these entrypoints are called is unspecified and may vary
+between different versions of the game.
+
+### Code reference types
+
+An entrypoint's code reference is turned into an instance of the
+entrypoint prototype's type. The most common way to make an entrypoint
+is to refer to a class which implements the expected type, but these
+code references can be made in multiple ways. Internally, a language
+adapter is responsible for interpreting the references and turning them
+into instances. The default language adapter is designed for Java code,
+and thus supports the following types of references:
+
+-   **Class reference**: ex. `net.fabricmc.example.ExampleMod` refers to
+    the non-abstract class by this name. The class must have a public
+    constructor with no arguments. The class must implement or extend
+    the expected type. The resulting object is a new instance of the
+    class.
+-   **Method reference**: ex. `net.fabricmc.example.ExampleMod::method`
+    refers to a public method in that class by that name. If the method
+    is nonstatic, a new instance of the class is constructed for the
+    method to be called on, meaning the class must be non-abstract and
+    also have a public constructor with no arguments. Methods can only
+    be used for interface types. The method must accept the same
+    arguments and have the same return type as the abstract method(s) in
+    the interface. The resulting value is a proxy implementation of the
+    interface, which will implement abstract methods by delegating to
+    this method.
+-   **Static field reference**: ex.
+    `net.fabricmc.example.ExampleMod::field` refers to the field in that
+    class by that name. The field must be static and public. The the
+    type of the field must be compatible with the expected type. The
+    resuling value is the value of that field.
+
+References to class members must be unambiguous, meaning the class must
+contain one and only one field or method with the targeted name. The
+language adapter cannot resolve methods overloads. In case of ambiguity,
+the entrypoint will fail to resolve.
+
+Language adapters for other languages can be implemented by mods.
+[fabric-language-kotlin](https://github.com/FabricMC/fabric-language-kotlin)
+provides a language adapter for Kotlin.
+
+### Other entrypoint applications
+
+Mods can call each others' entrypoints for integration purposes. An
+entrypoint is loaded lazily when entrypoints for a specific entrypoint
+prototype are requested, which makes an entrypoint an excellent tool for
+optional mod integrations. A mod may become an entrypoint prototype
+provider by declaring that other mods should provide entrypoints based
+on an entrypoint prototype, often using a class or interface that the
+mod provides in its API. Mods can safely use this class or interface
+even if the provider is not installed (rendering the class or interface
+inaccessible) because entrypoints are loaded only on request. When the
+provider is not present, the entrypoint will simply be ignored.
+
+Entrypoint instances can be accessed by calling
+`FabricLoader#getEntrypointContainers(name, type)`. This returns a list
+of entrypoint containers. These containers contain the entrypoint
+instance and the mod container of the mod which provided the instance.
+This can be used by a mod to determine which mods have registered an
+entrypoint.
+
+Entrypoint instances are memoized by their name and also their type.
+Using the same code reference for multiple entrypoints will result in
+multiple instances. Though highly absurd in practice, if
+`getEntrypoints` is called multiple times with the same name but
+different types, instances are constructed and memoized per type.
+
+### A note about load order and phases (or a lack thereof)
+
+Fabric Loader does not have a concept of a load order or loading phases.
+Initializer entrypoints are the mechanism with which most mod loading is
+usually done, but whether or not an initializer has been called does not
+determine whether or not a mod can be considered to be "loaded". Thus,
+it is unreasonable to expect that a mod has completed its modifications
+to the game after its initializers have been called. Additionally, the
+order in which entrypoints are called is mostly undefined and cannot be
+altered. The only guarantee is that a list of initializers in a
+fabric.mod.json file are called in the order in which they are declared.
+Fabric Loader does not provide multiple phases of initializers to work
+around the lack of order, either.
+
+A common example is the expectation that mod A should be able to load
+after mod B because mod A will replace an object registered by mod B.
+Alternatively, mod C wants to be loaded before mod D because mod D will
+do something in response to a registration performed by mod C. This is
+cannot be done for two reasons:
+
+1.  Mod initializers are not required to represent a transition in a
+    "mod loading lifecycle" so that after the initializer is called, all
+    its registry objects are registered.
+2.  The order in which mod initializers are called is undefined, and
+    cannot be influenced so that mod A's initializers are called after
+    mod B's initializers, or so that mod C's initializers are called
+    before mod D's initializers.
+
+Leaving aside the missing guarantee of registration of all objects in
+initializers, one might argue that there should therefore be other
+entrypoints to perform "pre-initialization" and "post-initialization" so
+that there is a sense of order. This creates a multi-phase loading
+scheme, which in practice creates issues with the establishment of
+conventions for which operations are to be performed in which phase,
+uncertainty and lack of adherence to these conventions and outliers
+which do not fit.

--- a/technical/fabric-loader.md
+++ b/technical/fabric-loader.md
@@ -1,0 +1,597 @@
+---
+title: Fabric Loader
+description: Technical information about Fabric Loader.
+---
+
+# Fabric Loader
+
+Fabric Loader is Fabric's lightweight mod loader. It provides the
+necessary tools to make Minecraft modifiable without depending on a
+specific version of the game. Game specific (and game version specific)
+hooks belong in Fabric API. It is possible to adapt Fabric Loader for
+many Java applications (for instance games like Slay the Spire and
+Starmade).
+
+Fabric Loader has services to allow mods to have some code executed
+during initialization, to transform classes, declare and provide mod
+dependencies, all in a number of different environments.
+
+For each Fabric Loader version, there is Javadoc available at
+
+    https://maven.fabricmc.net/docs/fabric-loader-[loader version]
+
+For example, Fabric Loader 0.11.1's documentation is at
+<https://maven.fabricmc.net/docs/fabric-loader-0.11.1/>
+
+## Features
+
+### Mods
+
+A mod is a jar with a [fabric.mod.json](/documentation/fabric_mod_json)
+mod metadata file in its root declaring how it should be loaded. It
+primarily declares a mod ID and version as well as
+[entrypoints](/documentation/entrypoint) and mixin configurations. The
+mod ID identifies the mod so that any mod with the same ID is considered
+to be the same mod. Only one version of a mod may be loaded at a time. A
+mod may declare other mods that it depends on or conflicts with. Fabric
+Loader will attempt to satisfy dependencies and load the appropriate
+versions of mods, or fail to launch otherwise.
+
+Fabric Loader makes all mods equally capable of modifying the game. As
+an example, anything Fabric API does can be done by any other mod.
+
+Mods are loaded both from the classpath and from the mods directory.
+They are expected to match the mappings in the current environment,
+meaning Fabric Loader will not remap any mods.
+
+### Nested JARs
+
+Nested JARs allow a mod to provide its own dependencies, so Fabric
+Loader can pick the best version matching the dependencies instead of
+requiring separate installation of dependencies. They also allow clean
+packaging of submodules, so each module can be used separately. Non-mod
+libraries can be repackaged as mods for nested JAR usage. A mod may
+bundle a number of other mods within its JAR. A nested JAR must itself
+also be a mod, which again can have nested JARs. Fabric Loader will load
+nested JARs while attempting to satisfy dependency constraints.
+
+Nested JARs are not extracted, they are instead loaded in in-memory file
+system using jimfs. See the
+[guidelines](/tutorial/loader04x#nested_jars) for how to use nested JARs
+effectively. Nested JARs must be declared by their paths relative to the
+containing JAR's root.
+
+### Entrypoints
+
+Fabric Loader has an [entrypoint](/documentation/entrypoint) system,
+which is used by mods to expose parts of the code for usage by Fabric
+Loader or other mods. Fabric Loader uses it for mod initialization.
+Initializers are loaded and called early during the game's
+initialization which allows a mod to run some code to make its
+modifications. These entrypoints are typically used to bootstrap mods by
+registering registry objects, event listeners and other callbacks for
+doing things later.
+
+### Mixin
+
+Mixin allows mods to transform Minecraft classes and even mod classes,
+and is the only method of class transformation that Fabric Loader
+officially supports. A mod can declare its own mixin configuration which
+enables the use of Mixin.
+
+Mixin was not specifically made for Fabric, so Fabric Loader uses a
+slightly modified version of Mixin. However, the documentation of the
+upstream version is still mostly valid. The modifications are mostly
+related to making it work without LegacyLauncher/LaunchWrapper.
+
+### Mappings
+
+Fabric Loader provides an API to determine names of classes, fields and
+methods with respect to the different environments that mods may be
+loaded in. This can be used to support reflection in any environment
+provided Fabric Loader has access to mappings to resolve the name.
+
+## Fabric Loader Internals
+
+### Deobfuscation
+
+When launched in a non-development environment, Fabric Loader will
+[remap](/tutorial/mappings) the Minecraft jar and realms client jar to
+intermediary names. Mods are expected to be mapped to intermediary,
+which will be compatible with this environment. The remapped jars are
+cached and saved in
+`${gameDir}/.fabric/remappedJars/${minecraftVersion}` for re-use across
+launches.
+
+### Class loading and transformation
+
+Fabric Loader depends on a custom class loader to transform some classes
+at runtime. Classes belonging to a mod or Minecraft are loaded with a
+class loader that applies transformations to classes before they are
+loaded. Other classes, those belonging to other libraries, cannot be
+transformed. With Knot, these classes are delegated to the default
+classloader for isolation and performance.
+
+Fabric Loader will perform side stripping on mod classes and Minecraft
+classes depending on the physical side that is launched. This involves
+completely removing classes, methods and fields annotated with
+`@Environment` annotations where the environment does not match. It also
+involves removing interface implementations on classes annotated with
+`@EnvironmentInterface` where the environment does not match. On
+Minecraft classes, this is used to simulate which classes and members
+that are available in the targeted runtime development environment. The
+annotation can be applied to mod classes to avoid class loading issues.
+
+Package access hacks might be applied to Minecraft classes depending on
+the mappings in the current environment. With official (obfuscated)
+names and intermediary names, most classes are placed in the same
+package. However, Yarn mappings place classes in various packages which
+sometimes creates illegal access violations due to the access rules of
+protected and package-private members. Therefore, in a development
+environment where such access issues are expected to exist, Minecraft
+classes are transformed so that package-private and protected members
+are made public. Outside a development environment we know that the
+package structure is flat, so the package access hack is not needed.
+Note that this transformation is applied at runtime, which means it is
+not visible in the source.
+
+### Launchers
+
+A launcher (not to be confused with the game launcher) is something
+provides a method to use Fabric Loader in a Java process. A launcher
+must provide a few features to support Fabric Loader's functionality
+such as class transformation and dynamic class loading. Knot and
+LegacyLauncher/LaunchWrapper are the current supported launchers.
+
+Knot is the default launcher included in Fabric Loader, designed
+specifically for Fabric Loader's features with support for modern
+versions of Java. Knot has the main classes
+`net.fabricmc.loader.launch.knot.KnotClient` and
+`net.fabricmc.loader.launch.knot.KnotServer` for clients and servers
+respectively.
+
+When launching a server using Knot in a production environment, the
+`net.fabricmc.loader.launch.server.FabricServerLauncher` main class must
+be used, which is a main class that wraps the launch of KnotServer. It
+can be configured with the `fabric-server-launcher.properties` placed in
+the current working directory. The file has one property, `serverJar`,
+whose value is 'server.jar' by default, which is used to configure the
+path to the minecraft server jar.
+
+Fabric Loader can also be launched with LegacyLauncher/LaunchWrapper
+using the tweakers `net.fabricmc.loader.launch.FabricClientTweaker` and
+`net.fabricmc.loader.launch.FabricServerTweaker` for clients and servers
+respectively. However, LegacyLauncher/LaunchWrapper support is currently
+outdated.
+
+## Integrating Fabric Loader into a dedicated application
+
+As stated above, Fabric Loader can be used outside of Minecraft to add
+mod loading for Java applications. This section will briefly summarize
+what do you need to do to integrate Fabric loader to your Java
+game/dedicated app. This was tested with **Gradle 7** (specifically
+7.3.1), **Java 8** and **IntelliJ IDEA 2022.3.1 (Community Edition)**.
+
+### Gradle dependencies
+
+First, you'll need to add Fabric Loader as a dependency, and its
+dependencies in you `build.gradle`:
+
+``` groovy
+repositories {
+    // your other repositories...
+    
+    maven {
+        url "https://repo.spongepowered.org/maven/"
+    }
+    maven {
+        url "https://maven.fabricmc.net/"
+    }
+}
+
+dependencies {
+    // your dependencies...
+    
+    implementation "net.fabricmc:fabric-loader:0.13.0"
+    implementation "net.fabricmc:access-widener:2.1.0"
+    implementation "net.fabricmc:tiny-mappings-parser:0.2.2.14"
+    implementation "com.google.guava:guava:21.0"
+    implementation "com.google.code.gson:gson:2.8.7"
+    implementation "org.ow2.asm:asm:9.2"
+    implementation "org.ow2.asm:asm-analysis:9.2"
+    implementation "org.ow2.asm:asm-commons:9.2"
+    implementation "org.ow2.asm:asm-tree:9.2"
+    implementation "org.ow2.asm:asm-util:9.2"
+}
+```
+
+### Launching your app with Fabric Loader
+
+If you've launched your app before through your own `main(String[])`, to
+incorporate Fabric Loader into your app, you will need to set its main
+class to use one of the Knot launchers. For client-side (or if you don't
+have client/server separation), specify
+`net.fabricmc.loader.impl.launch.knot.KnotClient` as your main class.
+For server-side only, specify
+`net.fabricmc.loader.impl.launch.knot.KnotServer`. You might ask, "but
+how will Fabric Loader know how to load my game?" That's where
+**GameProvider** comes into play.
+
+### Setting up GameProvider
+
+**GameProvider** is an interface that lets Fabric Loader locate your
+game, configure Fabric launcher, and then finally launch the game. For
+Fabric Loader to instantiate your implementation of **GameProvider**,
+you need to define it as a service that can be found by
+[ServiceLoader](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html).
+In your project's resources, create
+`META-INF/services/net.fabricmc.loader.impl.game.GameProvider` file, and
+paste into it the full class name to your **GameProvider**. Something
+like this:
+
+    net.developer.app.fabric.AppGameProvider
+
+This should allow Fabric Loader find your **GameProvider**. Now let's
+breakdown **GameProvider** interface.
+
+#### Implementing GameProvider
+
+For your game actually to launch, you need to carefully implement
+**GameProvider** in a specific way. Here is a breakdown of each method
+does:
+
+-   `getGameId()` and `getGameName()`, self-explanatory, app's ID like
+    `epic_app`, and app's name `Epic App`.
+-   `getRawGameVersion()` and `getNormalizedGameVersion()`, it's not
+    entirely clear, but raw version can include git-hash, or any
+    information about the game that developer may want to know (like
+    `v0.1.2+build17#f73acde`), while normalized version seems to be for
+    display (like `v0.1.2`).
+-   `getBuiltinMods()` allows you to provide built-in mod(s), which can
+    be used by mods to target specific version, but it's completely
+    optional, and you can just return `Collections.emptyList()`.
+-   `getEntryPoint()`, full class name of your main app class. It seems
+    to be used only in Minecraft.
+-   `getLaunchDirectory()` is a very important method. It should return
+    where the app's resources folder is (like configs, data, saves,
+    etc.). That's where Fabric Loader will create `config` and `mods`
+    folder, and from which mods will be loaded from!
+-   `isObfuscated()` whether your app is obfuscated.
+-   `requiresUrlClassLoader()` it forces **Fabric Loader** to use a
+    different compatibility class loader.
+-   `isEnabled()` whether your app is enabled. Just `return true;`
+-   `locateGame(FabricLauncher, String[])` that's where you need to
+    parse the arguments with `net.fabricmc.loader.impl.util.Arguments`,
+    locate the game directory and `return true;` if game directory was
+    found.
+-   `initialize(FabricLauncher)` here you can add extra configuration to
+    **FabricLauncher**. **Don't initialize your game here**!
+-   `getEntryPointTransformer()` return a
+    `net.fabricmc.loader.impl.game.patch.GameTransformer` that does
+    extra modification on the app's jar. If you're setting up Fabric
+    Loader to work with a separate app which you currently aren't
+    developing in your development environment, then simply return a
+    subclass of **GameTransformer** that returns `null` in its
+    `transform(String)` method.
+-   `unlockClassPath(FabricLauncher)` is called after transformers (i.e.
+    Mixin) were initialized and mods were detected and loaded (but not
+    initialized).
+-   `launch(ClassLoader)` this is where you launch your app.
+    **Important**: the app must be launched through reflection using the
+    given **ClassLoader**, about that later.
+-   `getArguments()` simply return the `Arguments` instance you
+    initialized in `locateGame(FabricLauncher, String[]))`.
+-   `getLaunchArguments(boolean)` simply
+    `return this.getArguments.toArray()`.
+
+An example **GameProvider** would look like this:
+
+``` java
+public class AppGameProvider implements GameProvider
+{
+    private Arguments arguments;
+    private Path gameDirectory;
+    private GameTransformer transformer = new AppGameTransformer();
+
+    @Override
+    public String getGameId()
+    {
+        return "app";
+    }
+
+    @Override
+    public String getGameName()
+    {
+        return "App";
+    }
+
+    @Override
+    public String getRawGameVersion()
+    {
+        return App.FULL_VERSION;
+    }
+
+    @Override
+    public String getNormalizedGameVersion()
+    {
+        return App.VERSION;
+    }
+
+    @Override
+    public Collection<BuiltinMod> getBuiltinMods()
+    {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getEntrypoint()
+    {
+        return "net.developer.app.App";
+    }
+
+    @Override
+    public Path getLaunchDirectory()
+    {
+        return this.gameDirectory;
+    }
+
+    @Override
+    public boolean isObfuscated()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean requiresUrlClassLoader()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled()
+    {
+        return true;
+    }
+
+    @Override
+    public boolean locateGame(FabricLauncher launcher, String[] args)
+    {
+        this.arguments = new Arguments();
+        this.arguments.parse(args);
+
+        this.gameDirectory = Paths.get(this.arguments.get("gameDirectory"));
+
+        return Files.isDirectory(this.gameDirectory);
+    }
+
+    @Override
+    public void initialize(FabricLauncher launcher)
+    {}
+
+    @Override
+    public GameTransformer getEntrypointTransformer()
+    {
+        return this.transformer;
+    }
+
+    @Override
+    public void unlockClassPath(FabricLauncher launcher)
+    {
+        for (Path path : this.jars)
+        {
+            launcher.addToClassPath(path);
+        }
+    }
+
+    @Override
+    public void launch(ClassLoader loader)
+    {
+        try
+        {
+            Class main = loader.loadClass(this.getEntrypoint());
+            Method method = main.getMethod("main", String[].class);
+
+            method.invoke(null, (Object) this.arguments.toArray());
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public Arguments getArguments()
+    {
+        return this.arguments;
+    }
+
+    @Override
+    public String[] getLaunchArguments(boolean sanitize)
+    {
+        return this.arguments.toArray();
+    }
+}
+```
+
+This class example assumes that argument `--gameDirectory` is the one
+that specifies where app's working directory is located. Adjust if
+needed.
+
+### Final touches
+
+Once you get Fabric Loading up and running in your app, you would see
+extra log in the console upon launching your app (if you did everything
+correctly):
+
+```txt:no-line-numbers
+[14:20:00] [INFO] [FabricLoader/GameProvider]: Loading App 0.1 (dev) with Fabric Loader 0.13.0
+[14:20:00] [INFO] [FabricLoader/]: Loading 2 mods:
+  - fabricloader 0.13.0
+  - java 8
+[14:20:01] [WARN] [FabricLoader/ModRemap]: Runtime mod remapping disabled due to no fabric.remapClasspathFile being specified. You may need to update loom.
+[14:20:01] [INFO] [FabricLoader/Mixin]: SpongePowered MIXIN Subsystem Version=0.8.5 Source=file:/C:/Users/Developer/.gradle/caches/modules-2/files-2.1/org.spongepowered/mixin/0.8.5/9d1c0c3a304ae6697ecd477218fa61b850bf57fc/mixin-0.8.5.jar Service=Knot/Fabric Env=CLIENT
+[14:20:01] [INFO] [FabricLoader/Mappings]: Mappings not present!
+```
+
+That's a good sign. However, that's not all.
+
+#### Initializing mods
+
+If you would try making a mod for your app either as a separate project
+or as a submodule in your project, there could be a couple of things
+that may not work either in development or in release. First thing is
+mods won't initialize. I.e. `ModInitializer.onInitialize()` won't be
+called. To fix that, simply call
+`net.fabricmc.loader.impl.game.minecraft.Hooks.startClient(File, Object)`
+(where `File` is game directory, and `Object` could be the main object
+of your game) somewhere after you initialized event busses, base
+registries, etc. so that mods could start modding your app.
+
+Something like this:
+
+``` java
+    public MainApp(App app)
+    {
+        super();
+
+        this.development = app.development;
+
+        this.events.register(this);
+        
+        this.registerCore(this, app.gameDirectory);
+        this.registerFactories();
+        this.registerFoundation();
+        this.registerMiscellaneous();
+        
+        Hooks.startClient(app.gameDirectory, app);
+
+        if (this.development)
+        {
+            this.watchDog = new WatchDog(this.assetsFolder);
+            this.watchDog.register(this.textures);
+            this.watchDog.register(this.models);
+            this.watchDog.register(this.sounds);
+            this.watchDog.start();
+        }
+    }
+```
+
+#### Mixins don't work?
+
+And finally, even if you registered Mixins in your mod, they may load,
+but they won't be able to actually patch their target class. If you have
+following message in the log:
+
+```txt:no-line-numbers
+[12:20:05] [WARN] [FabricLoader/Knot]: * CLASS LOADER MISMATCH! THIS IS VERY BAD AND WILL PROBABLY CAUSE WEIRD ISSUES! *
+  - Expected game class loader: net.fabricmc.loader.impl.launch.knot.KnotClassLoader@446a1e84
+  - Actual game class loader: null
+Could not find the expected class loader in game class loader parents!
+```
+
+Then it's the root of the issue. To fix this, you need to add your app's
+jar, or folder (in development) to `FabricLauncher`'s class path. This
+could be done by looking in the class path for your jar/folder, and
+detecting some key files unique to your app. Here is what you can do:
+
+``` java
+public class AppGameProvider implements GameProvider
+{
+    /* ... */
+    private List<Path> jars = new ArrayList<Path>();
+    private Set<String> jarFiles;
+
+    public AppGameProvider()
+    {
+        this.jarFiles = new HashSet<String>();
+
+        this.jarFiles.add("net/developer/app/App.class");
+        this.jarFiles.add("net/developer/app/MainApp.class");
+    }
+    
+    /* ... */
+
+    @Override
+    public boolean locateGame(FabricLauncher launcher, String[] args)
+    {
+        this.arguments = new Arguments();
+        this.arguments.parse(args);
+
+        this.gameDirectory = Paths.get(this.arguments.get("gameDirectory"));
+
+        for (Path path : launcher.getClassPath())
+        {
+            if (this.isHostApp(path))
+            {
+                this.jars.add(path);
+            }
+        }
+
+        return Files.isDirectory(this.gameDirectory);
+    }
+
+    private boolean isHostApp(Path path)
+    {
+        if (Files.isDirectory(path))
+        {
+            for (String string : this.jarFiles)
+            {
+                if (Files.exists(path.resolve(string)))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        try (ZipFile zip = new ZipFile(path.toFile()))
+        {
+            for (String string : this.jarFiles)
+            {
+                if (zip.getEntry(string) != null)
+                {
+                    return true;
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
+
+        return false;
+    }
+    
+    /* ... */
+
+    @Override
+    public void unlockClassPath(FabricLauncher launcher)
+    {
+        for (Path path : this.jars)
+        {
+            launcher.addToClassPath(path);
+        }
+    }
+    
+    /* ... */
+}
+```
+
+After detecting the app's jar(s)/folder(s) and adding them to
+`FabricLauncher`'s class path, Mixins should work in both development
+and release environment after that.
+
+#### Loading mods from classpath
+
+If you're testing the mod from the submodule that has your app and
+Fabric Loader in the classpath, instead of compiling the mod and placing
+it into app's launch directory, for Fabric Loader to load your mod from
+classpath, you need to add `-Dfabric.development=true` to JVM flags when
+running it, then mod(s) from classpath would be loaded too.
+
+For more reference check out [Fabric
+Loader's](https://github.com/FabricMC/fabric-loader) source,
+`net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider`, and
+this [GameProvider
+example](https://github.com/PseudoDistant/ExampleGameProvider).

--- a/technical/fabric-loom.md
+++ b/technical/fabric-loom.md
@@ -1,0 +1,398 @@
+---
+title: Fabric Loom
+description: Technical information about the Fabric Loom Gradle plugin.
+---
+
+# Fabric Loom
+
+Fabric Loom, or just Loom for short, is a [Gradle](https://gradle.org/)
+plugin for development of mods in the Fabric ecosystem. Loom provides
+utilities to install Minecraft and mods in a development environment so
+that you can link against them with respect to Minecraft obfuscation and
+its differences between distributions and versions. It also provides run
+configurations for use with Fabric Loader, Mixin compile processing and
+utilities for Fabric Loader's jar-in-jar system.
+
+### Useful tasks
+
+<!-- Todo, rewrite migrate mappings guide in the "develop" section? -->
+
+-   `migrateMappings`: Migrates the current source to the specified
+    mappings.
+-   `remapJar`: Produces a jar containing the remapped output of the
+    `jar` task. Also appends any included mods for jar-in-jar. Called
+    when running `build`.
+-   `genSources`: Decompile the minecraft jar using the default
+    decompiler (CFR).
+-   `downloadAssets`: Downloads the asset index and asset objects for
+    the configured version of Minecraft into the user cache.
+-   `genEclipseRuns`: Installs Eclipse run configurations and creates
+    the run directory if it does not already exist.
+-   `vscode`: Generates or overwrites a Visual Studio Code `launch.json`
+    file with launch configurations in the `.vscode` directory and
+    creates the run directory if it does not already exist.
+-   `ideaSyncTask`: Generates (but not overrides) the Intellij IDEA
+    launch config, including client and server by default.
+-   `remapSourcesJar`: Only exists if an AbstractArchiveTask
+    `sourcesJar` exists. Remaps the output of the `sourcesJar` task in
+    place.
+-   `runClient`: A JavaExec task to launch Fabric Loader as a Minecraft
+    client.
+-   `runServer`: A JavaExec task to launch Fabric Loader as a Minecraft
+    dedicated server.
+
+### Depending on Sub Projects
+
+When setting up a multi-project build that depenends on another loom
+project you should use the `namedElements` configuration when depending
+on the other project. By default a projects "outputs" are remapped to
+intermediary names. The `namedElements` configuration contains the
+project ouputs that have not been remapped.
+
+```groovy
+dependencies {
+  implementation project(path: ":name", configuration: "namedElements")
+}
+```
+
+If you are using splitsource sets in a multi-project build, you will
+also need to add a dependency for the other projects client sourceset.
+
+```groovy
+dependencies {
+  clientImplementation project(":name").sourceSets.client.output
+}
+```
+
+### Split Client and Common code
+
+For years a common source of server crashes has been from mods
+accidentally calling client only code when installed on a server. The
+latest loom and loader verions provide an option to require all client
+code to be moved into its own sourceset. This is done to provide a
+compile-time guarantee against calling client only Minecraft code or
+client only API on the server. A single jar file that works on both the
+client and server is still built from the two sourcesets.
+
+The following snippet from a build.gradle file shows how you can enable
+this for your mod. As your mod will now be split across two sourcesets,
+you will need to use the new DSL to define your mods sourcesets. This
+enables Fabric Loader to group your mods classpath together. This is
+also useful for some other complex multi-project setups.
+
+Minecraft 1.18 (1.19 recommended), Loader 0.14 and Loom 1.0 or later are
+required to split the client and common code.
+
+```groovy
+loom {
+  splitEnvironmentSourceSets()
+
+  mods {
+    modid {
+      sourceSet sourceSets.main
+      sourceSet sourceSets.client
+    }
+  }
+}
+```
+
+### Multi project Optimisation
+
+If your Gradle project has many subprojects that use the same Minecraft
+version such as Fabric-API, starting with Loom 1.1 you can now opt-in to
+advanced optimistations. Adding `fabric.loom.multiProjectOptimisation=true` to the gradle.properties file will help decrease build time and memory
+usage by sharing the Tiny Remapper instance between projects when
+remapping your output jars.
+
+### Options
+
+```groovy
+loom {
+  // Set the access widener path, see https://fabricmc.net/wiki/tutorial:accesswideners
+  accessWidenerPath = file("src/main/resources/modid.accesswidener")
+
+  // Add additional log4j config files.
+  log4jConfigs.from(file("log4j.xml"))
+
+  // When enabled the output archives will be automatically remapped.
+  remapArchives = true
+  // When enabled the -dev jars in the *Elements configurations will be replaced by the remapped jars
+  setupRemappedVariants = true
+  // When enabled transitive access wideners will be applied from dependencies.
+  enableTransitiveAccessWideners = true
+  // When enabled log4j will only be on the runtime classpath, forcing the use of SLF4j.
+  runtimeOnlyLog4j = false
+
+  // When set only server related features and jars will be setup.
+  serverOnlyMinecraftJar()
+  // When set the minecraft jar will be split into common and clientonly. Highly experimental, fabric-loader does not support this option yet.
+  splitMinecraftJar()
+
+  // Used to configure existing or new run configurations
+  runs {
+    client {
+      // Add a VM arg
+      vmArgs "-Dexample=true"
+      // Add a JVM property
+      property("example", "true")
+      // Add a program arg
+      programArg "--example"
+      // Add an environment variable
+      environmentVariable("example", "true")
+      // The environment (or side) to run, usually client or server.
+      environment = "client"
+      // The full name of the run configuration, i.e. 'Minecraft Client'. By default this is determined from the base name.
+      configName = "Minecraft Client"
+      // The default main class of the run configuration. This will be overridden if using a mod loader with a fabric_installer.json file.
+      defaultMainClass = ""
+      // The run directory for this configuration, relative to the root project directory.
+      runDir = "run"
+      // The sourceset to run, commonly set to sourceSets.test
+      source = sourceSets.main
+      // When true a run configuration file will be generated for IDE's. By default only set to true for the root project.
+      ideConfigGenerated = true
+
+      // Configure run config with the default client options.
+      client()
+
+      // Configure run config with the default server options.
+      server()
+    }
+
+    // Example of creating a basic run config for tests
+    testClient {
+      // Copies settings from another run configuration.
+      inherit client
+
+      configName = "Test Minecraft Client"
+      source = sourceSets.test
+    }
+
+                // Example of removing the built-in server configuration
+                remove server
+  }
+
+  // Configure all run configs to generate ide run configurations. Useful for sub projects.
+  runConfigs.configureEach {
+    ideConfigGenerated = true
+  }
+
+  // Used to configure mixin options or apply to additional source sets.
+  mixin {
+    // When disabled tiny remapper will be used to remap Mixins instead of the AP. Experimental.
+    useLegacyMixinAp = true
+    // Set the default refmap name
+    defaultRefmapName = "example.refmap.json"
+
+    // See https://github.com/FabricMC/fabric-loom/blob/dev/0.11/src/main/java/net/fabricmc/loom/api/MixinExtensionAPI.java for options to add additional sourcesets
+  }
+
+  // Configure or add new decompilers
+  decompilers {
+    // Configure a default decompiler, either cfr or fernflower
+    cfr {
+      // Pass additional options to the decompiler
+      options += [
+        key: "value"
+      ]
+      // Set the amount of memory in meagabytes used when forking the JVM
+      memory = 4096
+      // Set the maximum number of threads that the decompiler can use.
+      maxThreads = 8
+    }
+  }
+
+  interfaceInjection {
+    // When enabled injected interfaces from dependecies will be applied.
+    enableDependencyInterfaceInjection = true
+  }
+
+  // Splits the Minecraft jar and incoming dependencies across the main (common) and client only sourcesets.
+  // This provides compile time safety for accessing client only code.
+  splitEnvironmentSourceSets()
+
+  // This mods block is used group mods that are made up of multiplue classpath entries.
+  mods {
+    modid {
+      // When using split sources you should add the main and client sourceset
+      sourceSet sourceSets.main
+      sourceSet sourceSets.client
+    }
+  }
+
+  // Create modExampleImplementation and related configurations that remap mods.
+  createRemapConfigurations(sourceSets.example)
+}
+
+remapJar {
+  // Set the input jar for the task, also valid for remapSourcesJar
+  inputFile = file("example.jar")
+  // Set the source namespace, also valid for remapSourcesJar
+  sourceNamespace = "named"
+  // Set the target namespace, also valid for remapSourcesJar
+  targetNamespace = "intermediary"
+  // Add additional jar files to the remap classpath, also valid for remapSourcesJar
+  classpath.from file("classpath.jar")
+
+  // Add a nested mod jar to this task, the include configuration should be used for maven libraries and mods.
+  nestedJars.from file("nested.jar")
+  // When enabled nested jars will be included with the output jar.
+  addNestedDependencies = true
+}
+
+dependencies {
+  // Set the minecraft version.
+  minecraft "com.mojang:minecraft:1.18.1"
+
+  // Use mappings from maven.
+  mappings "net.fabricmc:yarn:1.18.1+build.22:v2"
+
+  // Use the offical mojang mappings
+  mappings loom.officialMojangMappings()
+
+  // Layered mappings using official mojang mappings and parchment.
+  mappings loom.layered() {
+    officialMojangMappings()
+    // Use parchment mappings. NOTE: Parchment maven must be manually added. (https://maven.parchmentmc.org)
+    parchment("org.parchmentmc.data:parchment-1.17.1:2021.09.05@zip")
+  }
+
+  // Remap a mod from maven and apply to gradle's implementation configuration
+  // (Minor detail: it's not exactly applied *to* the configuration, but a clone of it intended for mod dependencies)
+  modImplementation "net.fabricmc.fabric-api:fabric-api:0.46.2+1.18"
+
+  // Remap a mod from maven and apply to gradle's api configuration
+  modApi "net.fabricmc.fabric-api:fabric-api:0.46.2+1.18"
+
+  // Remap a mod from maven and apply to gradle's compileOnly configuration
+  modCompileOnly "net.fabricmc.fabric-api:fabric-api:0.46.2+1.18"
+
+  // Remap a mod from maven and apply to gradle's compileOnlyApi configuration
+  modCompileOnlyApi "net.fabricmc.fabric-api:fabric-api:0.46.2+1.18"
+
+  // Remap a mod from maven and apply to gradle's runtimeOnly configuration
+  modRuntimeOnly "net.fabricmc.fabric-api:fabric-api:0.46.2+1.18"
+
+  // Remap a mod from maven and apply to loom's localRuntime configuration.
+  // Behaves like runtimeOnly but is not exposed in to dependents. A bit like testRuntimeOnly but for mods.
+  modLocalRuntime "net.fabricmc.fabric-api:fabric-api:0.46.2+1.18"
+
+  // Include a mod jar in the remapped jar. None transitive.
+  include "example:example-mod:1.1.1"
+
+  // Include a none mod library jar in the remapped jar. A dummy mod will be generated. None transitive.
+  include "example:example-lib:1.1.1"
+
+  // Helper to aid with depending on a specific fabric api version.
+  modImplementation fabricApi.module("fabric-api-base", "0.46.2+1.18")
+
+  // Depend on a loom sub project by using the namedElements configuration.
+  implementation project(path: ":name", configuration: "namedElements")
+}
+```
+
+### Resolving issues
+
+Loom and/or gradle can sometimes fail due to corrupted cache files.
+Running `./gradlew build --refresh-dependencies` will force gradle and
+loom to re-download and recreate all of the files. This may take a few
+minutes but is usually quite successful with resolving cache related
+issues.
+
+### Development environment setup
+
+Loom is designed to work out of the box by simply setting up a workspace
+in the user's IDE of choice. It does quite a few things behind the
+scenes to create a development environment with Minecraft:
+
+1.  Downloads the client and server jar from official channels for the
+    configured version of Minecraft.
+2.  Merges the client and server jar to produce a merged jar with
+    `@Environment` and `@EnvironmentInterface` annotations.
+3.  Downloads the configured mappings.
+4.  Remaps the merged jar with intermediary mappings to produce an
+    intermediary jar.
+5.  Remaps the merged jar with yarn mappings to produce a mapped jar.
+6.  Optional: Decompiles the mapped jar to produce a mapped sources jar
+    and linemap, and applies the linemap to the mapped jar.
+7.  Adds dependencies of Minecraft.
+8.  Downloads Minecraft assets.
+9.  Processes and includes mod-augmented dependencies.
+
+### Caches
+
+-   `${GRADLE_HOME}/caches/fabric-loom`: The user cache, a cache shared
+    by all Loom projects for a user. Used to cache Minecraft assets,
+    jars, merged jars, intermediary jars and mapped jars.
+-   `.gradle/loom-cache`: The root project persistent cache, a cache
+    shared by a project and its subprojects. Used to cache remapped mods
+    as well as generated included mod JARs.
+-   `build/loom-cache`: The root project build cache.
+-   `**/build/loom-cache`: The (sub)project build cache.
+
+### Dependency configurations
+
+-   `minecraft`: Defines the version of Minecraft to be used in the
+    development environment.
+-   `mappings`: Defines the mappings to be used in the development
+    environment.
+-   `modCompile`, `modImplementation`, `modApi` and `modRuntime`:
+    Augmented variants of `compile`, `implementation`, `api` and
+    `runtime` for mod dependencies. Will be remapped to match the
+    mappings in the development environment and has any nested JARs
+    removed.
+-   `include`: Declares a dependency that should be included as a
+    jar-in-jar in the `remapJar` output. This dependency configuration
+    is not transitive. For non-mod dependencies, Loom will generate a
+    mod JAR with a fabric.mod.json using the name as the mod ID and the
+    same version.
+
+### Default configuration
+
+-   Applies the following plugins: `java`, `eclipse` and `idea`.
+-   Adds the following Maven repositories: Fabric
+    <https://maven.fabricmc.net/>, Mojang
+    <https://libraries.minecraft.net/> and Maven Central.
+-   Configures the `idea` extension to exclude directories `.gradle`,
+    `build`, `.idea` and `out`, to download javadocs sources and to
+    inherit output directories.
+-   Configures the `idea` task to be finalized by the `genIdeaWorkspace`
+    task.
+-   Configures the `eclipse` task to be finalized by the
+    `genEclipseRuns` task.
+-   If an `.idea` folder exists in the root project, downloads assets
+    (if not up-to-date) and installs run configurations in
+    `.idea/runConfigurations`.
+-   Adds `net.fabricmc:fabric-mixin-compile-extensions` and its
+    dependencies with the `annotationProcessor` dependency
+    configuration.
+-   Configures all non-test JavaCompile tasks with configurations for
+    the Mixin annotation processor.
+-   Configures the `remapJar` task to output a JAR with the same name as
+    the `jar` task output, then adds a "dev" classifier to the `jar`
+    task.
+-   Configures the `remapSourcesJar` task to process the `sourcesJar`
+    task output if the task exists.
+-   Adds the `remapJar` task and the `remapSourcesJar` task as
+    dependencies of the `build` task.
+-   Configures the `remapJar` task and the `remapSourcesJar` task to add
+    their outputs as `archives` artifacts when executed.
+-   For each MavenPublication (from the `maven-publish` plugin):
+    -   Manually appends dependencies to the POM for mod-augmented
+        dependency configurations, provided the dependency configuration
+        has a Maven scope.
+
+All run configurations have the run directory `${projectDir}/run` and
+the VM argument `-Dfabric.development=true`. The main classes for run
+configurations is usually defined by a `fabric-installer.json` file in
+the root of Fabric Loader's JAR file when it is included as a mod
+dependency, but the file can be defined by any mod dependency. If no
+such file is found, the main classes defaults to
+`net.fabricmc.loader.launch.knot.KnotClient` and
+`net.fabricmc.loader.launch.knot.KnotServer`.
+
+The client run configuration is configured with `--assetsIndex` and
+`--assetsDir` program arguments pointing to the loom cache directory
+containing assets and the index file for the configured version of
+Minecraft. When running on OSX, the "-XstartOnFirstThread" VM argument
+is added.

--- a/technical/index.md
+++ b/technical/index.md
@@ -1,0 +1,10 @@
+---
+title: Technical Information
+description: A collection of pages that go over the technical details of the Fabric toolchain
+---
+
+# Technical Information
+
+These pages go over the various technical information about key components in the Fabric toolchain.
+
+You can also view various specifications for file formats used in the toolchain as well.

--- a/technical/specifications/enigma.md
+++ b/technical/specifications/enigma.md
@@ -1,0 +1,156 @@
+---
+title: Enigma Specification
+description: The specification for the Enigma mappings file format.
+---
+
+# Enigma Mapping Format
+
+The Enigma mapping format consists of a list of hierarchical sections.
+Every line starts a new section, whether it continues an existing
+section is determined by the indentation level. A section's parent is
+always the closest preceding section indented once less than itself.
+Accordingly, a section ends just before the next line with the same or a
+lesser indentation level.
+
+The child-to-parent relationships form the paths to uniquely identify
+any element globally. For example, all method and field sections that
+are children of a class section represent members of the represented
+class. Sections need to be unique within their level. For example a
+specific class may only be recorded once, a comment can't be redefined
+or the same parameter listed twice.
+
+Supported elements are classes, fields, methods, parameters and
+comments. If you need support for variables, namespaces, arbitrary
+top-level metadata and more resistance against obfuscated names, [Tiny
+v2](./tiny/v2.md) is recommended instead.
+
+**Example:**
+
+```enigma:no-line-numbers
+CLASS a pkg/SomeClass
+  FIELD a	someField [I
+  METHOD a someMethod (III)V
+    ARG 1 amount
+    # This is a file comment. It can be put basically everywhere, except in the same line as a COMMENT.
+CLASS b pkg/xy/AnotherClass ACC:PUBLIC
+  COMMENT This is a
+  COMMENT multiline comment. You can use <b>HTML tags</b> if you like, or leave
+  COMMENT
+  COMMENT empty lines.
+  METHOD a anotherMethod (Ljava/lang/String;)I
+  CLASS c InnerClass
+    COMMENT This class's obfuscated fully qualified name is {@code b$c}.
+```
+
+## Grammar
+
+```bnf:no-line-numbers
+<file>                          ::= <content>
+<content>                       ::= '' | <class-section> <content>
+
+<class-section>                 ::= <class-section-indentation> 'CLASS' <space> <class-name-a> <class-name-b> <formatted-access-modifier> <eol> <class-sub-sections>
+<class-section-indentation>     ::= '' | <tab> <class-section-indentation>
+<class-name-a>                  ::= <class-name>
+<class-name-b>                  ::= <optional-class-name>
+<optional-class-name>           ::= <empty-mapping> | <space> <class-name>
+<class-name>                    ::= <spaceless-safe-string>
+<class-sub-sections>            ::= '' | <class-comment-section> <class-sub-sections> | <field-section> <class-sub-sections> | <method-section> <class-sub-sections> | <class-section> <class-sub-sections>
+
+<field-section>                 ::= <class-section-indentation> <tab> 'FIELD' <space> <field-name-a> <field-name-b> <formatted-access-modifier> <field-desc-a> <eol> <field-sub-sections>
+<field-name-a>                  ::= <field-name>
+<field-name-b>                  ::= <optional-field-name>
+<optional-field-name>           ::= <empty-mapping> | <space> <field-name>
+<field-name>                    ::= <spaceless-safe-string>
+<field-desc-a>                  ::= <field-desc>
+<field-desc>                    ::= <spaceless-safe-string>
+<field-sub-sections>            ::= '' | <member-comment-section> <field-sub-sections>
+
+<method-section>                ::= <class-section-indentation> <tab> 'METHOD' <space> <method-name-a> <method-name-b> <formatted-access-modifier> <method-desc-a> <eol> <method-sub-sections>
+<method-name-a>                 ::= <method-name>
+<method-name-b>                 ::= <optional-method-name>
+<optional-method-name>          ::= <empty-mapping> | <space> <method-name>
+<method-name>                   ::= <spaceless-safe-string>
+<method-desc-a>                 ::= <method-desc>
+<method-desc>                   ::= <spaceless-safe-string>
+<method-sub-sections>           ::= '' | <member-comment-section> <method-sub-sections> | <method-parameter-section> <method-sub-sections>
+
+<method-parameter-section>      ::= <class-section-indentation> <tab> <tab> 'ARG' <space> <lv-index> <space> <parameter-name-b> <eol> <method-parameter-sub-sections>
+<lv-index>                      ::= <non-negative-int>
+<parameter-name-b>              ::= <optional-parameter-name>
+<optional-parameter-name>       ::= <empty-mapping> | <space> <parameter-name>
+<parameter-name>                ::= <spaceless-safe-string>
+<method-parameter-sub-sections> ::= '' | <parameter-comment-section> <method-parameter-sub-sections>
+
+<empty-mapping>                 ::= '' | <space> '-'
+<formatted-access-modifier>     ::= '' | <space> 'ACC:' <access-modifier>
+<access-modifier>               ::= 'UNCHANGED' | 'PUBLIC' | 'PROTECTED' | 'PRIVATE'
+
+<class-comment-section>         ::= '' | <class-section-indentation> <tab> <indented-comment-section> <eol> <class-comment-section>
+<member-comment-section>        ::= '' | <class-section-indentation> <tab> <tab> <tab> <indented-comment-section> <eol> <member-comment-section>
+<parameter-comment-section>     ::= '' | <class-section-indentation> <tab> <tab> <tab> <tab> <indented-comment-section> <eol> <parameter-comment-section>
+<indented-comment-line>         ::= 'COMMENT' <comment-content-line>
+<comment-content-line>          ::= <safe-string>
+```
+
+### Notes
+
+-   `<tab>` is `\t`.
+-   `<space>` is the space character (`U+0020`).
+-   `<eol>` is `\n` or `\r\n`.
+-   `<safe-string>` is a non-empty string that must not contain:
+    -   `\`,
+    -   `\n`,
+    -   `\r`,
+    -   `\t` or
+    -   `\0`.
+-   `<spaceless-safe-string>` is the same as `<safe-string>`, but in
+    addition mustn't contain `<space>` as well.
+-   Each line of an unprocessed comment string gets its own
+    `<comment-content-line>`.
+-   `<non-negative-int>` is any integer from 0 to 2147483647 (2^31-1)
+    inclusive, represented as per `java.lang.Integer.toString()`.
+-   `<class-name>`, is the binary name of a class as specified in JVMS
+    SE 8 §4.2.1. Inner classes get their own `<class-section>` within
+    their outer class's `<class-section>`. The outer names should be
+    omitted then, though older versions of the format didn't do this.
+-   `<class-section-indentation>` is `''` for top-level
+    `<class-section>`s. Inner classes' `<class-section-indentation>`
+    increases by one `<tab>` per nest level. E.g. a doubly-nested inner
+    class `Outer$Inner$InnerInner` must have a
+    `<class-section-indentation>` of one `<tab>` for `Inner` and two
+    `<tab>`s for `InnerInner`.
+-   `<field-name>`/`<method-name>`/`<parameter-name>` is the unqualified
+    name of a field/method/parameter as specified in JVMS SE 8 §4.2.2.
+-   `<field-desc>` is a field descriptor as specified in JVMS SE 8
+    §4.3.2.
+-   `<method-desc>` is a method descriptor as specified in JVMS SE 8
+    §4.3.3.
+-   `<lv-index>` refers to the local variable array index of the frames
+    having the variable, see "index" in JVMS SE 8 §4.7.13.
+
+## Miscellaneous Notes
+
+-   The encoding for the entire file is UTF-8. Escape sequences are
+    limited to the types, locations and conditions mentioned above.
+-   Indenting uses tab characters exclusively, one tab character equals
+    one level. The amount of leading tab characters is at most 1 more
+    than in the preceding line.
+-   Sections with unknown types should be skipped without generating an
+    error.
+-   Sections representing the same element must not be repeated, e.g.
+    there can be only one top-level section for a specific class or one
+    class-level section for a specific member.
+-   Mappings without any (useful) names should be omitted.
+-   Sections without any (useful) mappings or sub-sections should be
+    omitted.
+-   Comments should be without their enclosing syntax elements,
+    indentation or decoration. For example, the comment
+           /**
+            * A comment
+            * on two lines.
+            */
+
+    (note the indentation) should be recorded as
+        COMMENT A comment
+        COMMENT on two lines.
+

--- a/technical/specifications/fabric-mod-json.md
+++ b/technical/specifications/fabric-mod-json.md
@@ -1,0 +1,100 @@
+---
+title: fabric.mod.json Specification (v1)
+description: The latest (v1) specification for the fabric.mod.json file.
+---
+
+# `fabric.mod.json` Specification (v1)
+
+This page covers the latest (v1) specification for the `fabric.mod.json` file used to identify Fabric mods.
+
+## Definitions
+
+### Entrypoint
+
+Defines the entrypoint for the mod.
+
+#### Properties
+
+- `adapter` (String): The language adapter to use. Default value is `"default"`.
+- `value` (String): The entrypoint function or class.
+
+### Contact Information
+
+Information for contacting mod authors.
+
+#### Properties
+
+- `email` (String): Contact e-mail pertaining to the mod.
+- `irc` (String): IRC channel pertaining to the mod. Must be a valid URL format.
+- `homepage` (String): Project or user homepage. Must be a valid HTTP/HTTPS address.
+- `issues` (String): Project issue tracker. Must be a valid HTTP/HTTPS address.
+- `sources` (String): Project source code repository. Must be a valid URL.
+
+### Environment
+
+Defines the environment where this mod will be loaded.
+
+- Enum Values: `*`, `client`, `server`
+
+### Nested Jar
+
+Describes a nested JAR to be loaded alongside the outer mod JAR.
+
+#### Properties
+
+- `file` (String): A string value pointing to a path from the root of the JAR to a nested JAR.
+
+### Person
+
+Represents an individual associated with the mod.
+
+#### Properties
+
+- `name` (String): The name of the person.
+- `contact` (Object): Contact information for the person.
+
+### Version Ranges
+
+Defines version ranges for the mod.
+
+### Version Range
+
+Represents a version range that matches versions.
+
+## Properties
+
+- `id` (String): The mod identifier.
+- `version` (String): The mod version.
+- `schemaVersion` (Integer): The version of the fabric.mod.json schema. It's a constant set to `1`.
+- `environment` (Environment): Reference to the environment definition.
+- `entrypoints` (Object): The entrypoints used by this mod.
+  - `main` (Array of Entrypoint): The entrypoint for all environments (classes must implement ModInitializer).
+  - `client` (Array of Entrypoint): The entrypoint for the client environment (classes must implement ClientModInitializer).
+  - `server` (Array of Entrypoint): The entrypoint for the server environment (classes must implement DedicatedServerModInitializer).
+  - `preLaunch` (Array of Entrypoint): The entrypoint called just before the game instance is created (classes must implement PreLaunchEntrypoint).
+  - `fabric-datagen` (Array of Entrypoint): The entrypoint for the data generator environment (classes must implement DataGeneratorEntrypoint).
+  - `fabric-gametest` (Array of Entrypoint): The entrypoint for the Game Test environment (classes must implement FabricGameTest).
+  - `...` (Array of Entrypoint): Custom mod entrypoints, you should refer to the mod's code to determine the interface to implement and what the entrypoint ID value is.
+- `jars` (Array of Nested Jar): Contains an array of nestedJar objects.
+- `languageAdapters` (Object): A string→string dictionary, connecting namespaces to LanguageAdapter implementations.
+- `mixins` (Array): Paths to mixin files or objects defining mixin paths and environment.
+- `accessWidener` (String): Path to an access widener definition file.
+- `depends` (Object): id→versionRange map for dependencies causing a hard failure if not met.
+- `recommends` (Object): id→versionRange map for dependencies causing a soft failure (warning) if not met.
+- `suggests` (Object): id→versionRange map for dependencies used as metadata.
+- `conflicts` (Object): id→versionRange map for dependencies causing a soft failure (warning) if met.
+- `breaks` (Object): id→versionRange map for dependencies causing a hard failure if met.
+- `name` (String): Name of the mod.
+- `description` (String): Description of the mod.
+- `authors` (Array of Person): The direct authorship information.
+- `contributors` (Array of Person): Contributors to this mod.
+- `contact` (Contact Information): Contact information for the mod.
+- `license` (String or Array of Strings): The license(s) the mod uses.
+- `icon` (String or Object): Path(s) to PNG file(s) for the mod icon(s).
+- `custom` (Object): A map of namespace:id→value for custom data fields.
+
+## Required Fields
+
+- `id`
+- `version`
+- `schemaVersion`

--- a/technical/specifications/tiny/v1.md
+++ b/technical/specifications/tiny/v1.md
@@ -1,0 +1,128 @@
+---
+title: Tiny Specification (v1)
+description: The v1 specification for the Tiny mappings file format.
+---
+
+# Tiny v1
+
+Tiny v1 consists of a list of flat (non-hierarchical) mapping entries.
+Every line in the content section corresponds to a new entry. Supported
+elements are classes, fields and methods; for parameters, variables,
+comments and a generally more space-efficient format, it's recommended
+to use its successor, [Tiny v2](./v2.md).
+
+**Example:**
+
+```tiny:no-line-numbers
+v1  official  intermediary  named
+# INTERMEDIARY-COUNTER class 289
+# INTERMEDIARY-COUNTER field 945
+# INTERMEDIARY-COUNTER method 1204
+# SORTED-HIERARCHY
+CLASS a class_123	pkg/SomeClass
+FIELD	a	[I	a	field_789	someField
+FIELD	a	Lyj;	b	field_790	someField2
+METHOD	a	(III)V	a	method_456	someMethod
+METHOD	a	()F	b	method_479	someMethod2
+CLASS	b	class_234	pkg/xy/AnotherClass
+METHOD	b	(Ljava/lang/String;)I	a	method_567	anotherMethod
+```
+
+
+## Grammar
+
+```bnf:no-line-numbers 
+<file>                  ::= <header> | <header> <content>
+
+<header>                ::= 'v1' <tab> <namespace-a> <tab> <namespace-b> <extra-namespaces> <eol> <properties>
+<namespace-a>           ::= <namespace>
+<namespace-b>           ::= <namespace>
+<extra-namespaces>      ::= '' | <tab> <namespace> <extra-namespaces>
+<namespace>             ::= <safe-string>
+
+<properties>            ::= '' | '#' <space> <property> <eol> <properties>
+<property>              ::= <property-key> | <property-key> <space> <property-value>
+<property-key>          ::= <safe-string>
+<property-value>        ::= <spaceless-safe-string>
+
+<content>               ::= '' | <mapping-entry> <content> <properties>
+<mapping-entry>         ::= <class-entry> | <field-entry> | <method-entry>
+
+<class-entry>           ::= 'CLASS' <tab> <class-name-a> <tab> <class-name-b> <extra-ns-class-names>
+<class-name-a>          ::= <class-name>
+<class-name-b>          ::= <optional-class-name>
+<optional-class-name>   ::= '' | <class-name>
+<extra-ns-cls-names>    ::= '' | <tab> <optional-class-name> <extra-ns-class-names>
+<class-name>            ::= <safe-string>
+
+<field-entry>           ::= 'FIELD' <tab> <parent-class-name-a> <tab> <field-desc-a> <tab> <field-name-a> <tab> <field-name-b> <extra-ns-field-names>
+<field-name-a>          ::= <field-name>
+<field-name-b>          ::= <optional-field-name>
+<optional-field-name>   ::= '' | <field-name>
+<extra-ns-field-names>  ::= '' | <tab> <optional-field-name> <extra-ns-field-names>
+<field-name>            ::= <safe-string>
+<field-desc-a>          ::= <field-desc>
+<field-desc>            ::= <safe-string>
+
+<method-entry>          ::= 'METHOD' <tab> <parent-class-name-a> <tab> <method-desc-a> <tab> <method-name-a> <tab> <method-name-b> <extra-ns-method-names>
+<method-name-a>         ::= <method-name>
+<method-name-b>         ::= <optional-method-name>
+<optional-method-name>  ::= '' | <method-name>
+<extra-ns-method-names> ::= '' | <tab> <optional-method-name> <extra-ns-method-names>
+<method-name>           ::= <safe-string>
+<method-desc-a>         ::= <method-desc>
+<method-desc>           ::= <safe-string>
+```
+
+### Notes
+
+-   `<tab>` is `\t`.
+-   `<space>` is the space character (`U+0020`).
+-   `<eol>` is `\n` or `\r\n`.
+-   `<safe-string>` is a non-empty string that must not contain:
+    -   `\`,
+    -   `\n`,
+    -   `\r`,
+    -   `\t` or
+    -   `\0`.
+-   `<spaceless-safe-string>` is the same as `<safe-string>`, but in
+    addition mustn't contain `<space>` as well.
+-   `<properties>` are either in the `<header>` or at the bottom of the
+    file, *not* scattered across both locations.
+-   `<class-name>` is the binary name of a class as specified in JVMS SE
+    8 §4.2.1. Nested class identifiers are typically separated with `$`
+    (e.g. `some/package/class$nested$subnested`). Outer names must not
+    be omitted for any namespace.
+-   `<parent-class-name-a>` is the `<class-name>` of the entry's parent
+    (owning) class.
+-   `<field-name>`/`<method-name>` is the unqualified name of a
+    field/method specified in JVMS SE 8 §4.2.2.
+-   `<field-desc>` is a field descriptor as specified in JVMS SE 8
+    §4.3.2.
+-   `<method-desc>` is a method descriptor as specified in JVMS SE 8
+    §4.3.3.
+
+## Miscellaneous Notes
+
+-   The encoding for the entire file is UTF-8.
+-   Properties with unknown keys should be skipped without generating an
+    error.
+-   The amount of extra namespaces defined in the header and the amount
+    of names in every `extra-ns-*-names` definition have to match. They
+    are associated by their relative position, like the mandatory
+    namespaces `a` and `b` that are associated by the suffix, e.g.
+    `namespace-a` covers `class-name-a`, `field-name-a`, `field-desc-a`,
+    `method-name-a` and `method-desc-a`.
+-   Entries representing the same element should not be repeated, so
+    there can be only one entry for a specific class, member or
+    property.
+-   Mappings without any (useful) names should be omitted.
+-   Entries without any (useful) mappings should be omitted.
+
+## Standard Properties
+
+These are required to be in the header.
+
+-   `SORTED-HIERARCHY`: all member entries are directly beneath their
+    parent class entries, and fields are before methods
+````

--- a/technical/specifications/tiny/v2.md
+++ b/technical/specifications/tiny/v2.md
@@ -1,0 +1,193 @@
+---
+title: Tiny Specification (v2)
+description: The v2 specification for the Tiny mappings file format.
+---
+
+# Tiny v2
+
+Tiny v2 consists of a list of hierarchical sections. Every line starts a
+new section, whether it continues an existing section is determined by
+the indentation level. A section's parent is always the closest
+preceding section indented once less than itself. Accordingly, a section
+ends just before the next line with the same or a lesser indentation
+level.
+
+The child-to-parent relationships form the paths to uniquely identify
+any element globally. For example, all field and method sections that
+are children of a class section represent members of the represented
+class.
+
+Sections need to be unique within their level. For example a specific
+class may only be recorded once, a comment can't be redefined or the
+same parameter listed twice.
+
+**Example:**
+
+```tiny:no-line-numbers
+tiny	2	0	official	intermediary	named
+  someProperty	someValue
+  anotherProperty
+c	a	class_123	pkg/SomeClass
+  f	[I	a	field_789	someField
+  m	(III)V	a	method_456	someMethod
+    p	1		param_0	x
+    p	2		param_1	y
+    p	3		param_2	z
+    c	Just a method for demonstrating the format.
+c	b	class_234	pkg/xy/AnotherClass
+  m	(Ljava/lang/String;)I	a	method_567	anotherMethod
+```
+
+## Grammar
+
+```bnf:no-line-numbers
+<file>                          ::= <header> | <header> <content>
+
+<header>                        ::= 'tiny' <tab> <major-version> <tab> <minor-version> <tab> <namespace-a> <tab> <namespace-b> <extra-namespaces> <eol> <properties>
+<major-version>                 ::= <non-negative-int>
+<minor-version>                 ::= <non-negative-int>
+<namespace-a>                   ::= <namespace>
+<namespace-b>                   ::= <namespace>
+<extra-namespaces>              ::= '' | <tab> <namespace> <extra-namespaces>
+<namespace>                     ::= <safe-string>
+
+<properties>                    ::= '' | <tab> <property> <eol> <properties>
+<property>                      ::= <property-key> | <property-key> <tab> <property-value>
+<property-key>                  ::= <safe-string>
+<property-value>                ::= <escaped-string>
+
+<content>                       ::= '' | <class-section> <content>
+
+<class-section>                 ::= 'c' <tab> <class-name-a> <tab> <class-name-b> <extra-ns-class-names> <eol> <class-sub-sections>
+<class-name-a>                  ::= <class-name>
+<class-name-b>                  ::= <optional-class-name>
+<optional-class-name>           ::= '' | <class-name>
+<extra-ns-cls-names>            ::= '' | <tab> <optional-class-name> <extra-ns-class-names>
+<class-name>                    ::= <conf-safe-string>
+<class-sub-sections>            ::= '' | <class-comment-section> <class-sub-sections> | <field-section> <class-sub-sections> | <method-section> <class-sub-sections>
+
+<field-section>                 ::= <tab> 'f' <tab> <field-desc-a> <tab> <field-name-a> <tab> <field-name-b> <extra-ns-field-names> <eol> <field-sub-sections>
+<field-name-a>                  ::= <field-name>
+<field-name-b>                  ::= <optional-field-name>
+<optional-field-name>           ::= '' | <field-name>
+<extra-ns-field-names>          ::= '' | <tab> <optional-field-name> <extra-ns-field-names>
+<field-name>                    ::= <conf-safe-string>
+<field-desc-a>                  ::= <field-desc>
+<field-desc>                    ::= <conf-safe-string>
+<field-sub-sections>            ::= '' | <member-comment-section> <field-sub-sections>
+
+<method-section>                ::= <tab> 'm' <tab> <method-desc-a> <tab> <method-name-a> <tab> <method-name-b> <extra-ns-method-names> <eol> <method-sub-sections>
+<method-name-a>                 ::= <method-name>
+<method-name-b>                 ::= <optional-method-name>
+<optional-method-name>          ::= '' | <method-name>
+<extra-ns-method-names>         ::= '' | <tab> <optional-method-name> <extra-ns-method-names>
+<method-name>                   ::= <conf-safe-string>
+<method-desc-a>                 ::= <method-desc>
+<method-desc>                   ::= <conf-safe-string>
+<method-sub-sections>           ::= '' | <member-comment-section> <method-sub-sections> | <method-parameter-section> <method-sub-sections> | <method-variable-section> <method-sub-sections>
+
+<method-parameter-section>      ::= <tab> <tab> 'p' <tab> <lv-index> <tab> <var-name-a> <tab> <var-name-b> <extra-ns-var-names> <eol> <method-parameter-sub-sections>
+<var-name-a>                    ::= <optional-var-name>
+<var-name-b>                    ::= <optional-var-name>
+<optional-var-name>             ::= '' | <var-name>
+<extra-ns-var-names>            ::= '' | <tab> <optional-var-name> <extra-ns-var-names>
+<var-name>                      ::= <conf-safe-string>
+<lv-index>                      ::= <non-negative-int>
+<method-parameter-sub-sections> ::= '' | <var-comment-section> <method-parameter-sub-sections>
+
+<method-variable-section>       ::= <tab> <tab> 'v' <tab> <lv-index> <tab> <lv-start-offset> <tab> <optional-lvt-index> <tab> <var-name-a> <tab> <var-name-b> <extra-ns-var-names> <eol> <method-variable-sub-sections>
+<lv-start-offset>               ::= <non-negative-int>
+<optional-lvt-index>            ::= '-1' | <lvt-index>
+<lvt-index>                     ::= <non-negative-int>
+<method-variable-sub-sections>  ::= '' | <var-comment-section> <method-variable-sub-sections>
+
+<comment>                       ::= <escaped-string>
+<class-comment-section>         ::= <tab> 'c' <tab> <comment> <eol>
+<member-comment-section>        ::= <tab> <tab> 'c' <tab> <comment> <eol>
+<var-comment-section>           ::= <tab> <tab> <tab> 'c' <tab> <comment> <eol>
+```
+
+### Notes
+
+-   `<tab>` is `\t`.
+-   `<eol>` is `\n` or `\r\n`.
+-   `<safe-string>` is a non-empty string that must not contain:
+    -   `\`,
+    -   `\n`,
+    -   `\r`,
+    -   `\t` or
+    -   `\0`.
+-   `<conf-safe-string>` is the same as `<safe-string>` if
+    `<properties>` doesn't contain a `<property>` `escaped-names`,
+    otherwise it's a non-empty string further described by
+    `<escaped-string>`.
+-   `<escaped-string>` is a string that must not contain an `<eol>`,
+    escapes `\` to `\\` and the other forbidden values to their string
+    literal equivalents, as seen in the list above.
+-   `<non-negative-int>` is any integer from 0 to 2147483647 (2^31-1)
+    inclusive, represented as per `java.lang.Integer.toString()`.
+-   `<class-name>`, once optionally unescaped, is the binary name of a
+    class as specified in JVMS SE 8 §4.2.1. Nested class identifiers are
+    typically separated with `$` (e.g.
+    `some/package/class$nested$subnested`). Outer names must not be
+    omitted for any namespace.
+-   `<field-name>`/`<method-name>`/`<var-name>`, once optionally
+    unescaped, is the unqualified name of a field/method/variable as
+    specified in JVMS SE 8 §4.2.2.
+-   `<field-desc>`, once optionally unescaped, is a field descriptor as
+    specified in JVMS SE 8 §4.3.2.
+-   `<method-desc>`, once optionally unescaped, is a method descriptor
+    as specified in JVMS SE 8 §4.3.3.
+-   `<lv-index>` refers to the local variable array index of the frames
+    having the variable, see "index" in JVMS SE 8 §4.7.13.
+-   `<lv-start-offset>` is at most the start of the range in which the
+    variable has a value, but doesn't overlap with another variable with
+    the same `<lv-index>`, see "start_pc" in JVMS SE 8 §4.7.13. The
+    start offset/range for Tiny v2 is measured in instructions with a
+    valid opcode, not bytes.
+-   `<lvt-index>` is the index into the LocalVariableTable attribute's
+    `local_variable_table array`, see "local_variable_table" in JVMS SE
+    8 §4.7.13, not to be confused with "index" referred by `<lv-index>`.
+
+## Miscellaneous Notes
+
+-   The encoding for the entire file is UTF-8. Escape sequences are
+    limited to the types, locations and conditions mentioned above.
+-   Indenting uses tab characters exclusively, one tab character equals
+    one level. The amount of leading tab characters is at most 1 more
+    than in the preceding line.
+-   Sections or properties with unknown types/keys should be skipped
+    without generating an error.
+-   The amount of extra namespaces defined in the header and the amount
+    of names in every `extra-ns-*-names` definition have to match. They
+    are associated by their relative position, like the mandatory name
+    spaces `a` and `b` that are associated by the suffix, e.g.
+    `namespace-a` covers `class-name-a`, `field-name-a`, `field-desc-a`,
+    `method-name-a`, `method-desc-a` and `var-desc-a`,.
+-   Sections representing the same element must not be repeated, e.g.
+    there can be only one top-level section for a specific class or one
+    class-level section for a specific member.
+-   If any variable mapping doesn't specify a LVT index, e.g. due to a
+    missing `LocalVariableTable` attribute in one of the methods, the
+    property `missing-lvt-indices` has to be added to.
+-   Mappings without any (useful) names should be omitted.
+-   Sections without any (useful) mappings or sub-sections should be
+    omitted.
+-   Comments should be without their enclosing syntax elements,
+    indentation or decoration. For example, the comment:
+
+    ```java
+    /**
+      * A comment
+      * on two lines.
+      */
+    ```
+
+    (note the indentation) should be recorded as `A comment\<eol\>on two lines.`
+      
+
+## Standard Properties
+
+-   `escaped-names`: deserialize values with unescaping
+-   `missing-lvt-indices`: expect local variable mappings without a
+    lvt-index value

--- a/technical/yarn.md
+++ b/technical/yarn.md
@@ -1,0 +1,40 @@
+---
+title: Yarn
+description: Technical Information about Yarn, the open source mappings used by the majority of Fabric projects.
+---
+
+# Yarn
+
+Yarn is a set of open, unencumbered Minecraft mappings, free for everyone to use under the Creative Commons Zero license. The intention is to let everyone mod Minecraft freely and openly, while also being able to innovate and process the mappings as they see fit.
+
+Yarn uses the [Enigma](./specifications/enigma.md) mappings format to store the mapped classes, fields and methods that are obfuscated.
+
+You can view these Enigma mappings in the `/mappings` folder of the [GitHub Repository](https://github.com/FabricMC/yarn).
+
+## Contributing to Yarn
+
+::: warning
+You will need a considerably powerful computer to open the Enigma GUI due to the sheer amount of mapping files that are loaded. 
+
+You should also have a read of Yarn's [Contributing Guidelines](https://github.com/FabricMC/yarn/blob/23w51b/CONTRIBUTING.md) and [Conventions](https://github.com/FabricMC/yarn/blob/23w51b/CONVENTIONS.md) before making any changes.
+:::
+
+To contribute to yarn, simply clone the repository and open it in IntelliJ IDEA or a similar Java IDE.
+
+Once the project has loaded, simply run the `yarn` task via your IDE or `./gradlew yarn` in a terminal.
+
+This should open the Enigma GUI, where you can modify the mappings easily.
+
+*For more information on Enigma, you should refer to the [Enigma](./enigma.md) technical page.*
+
+Once you've made your changes, make sure to save and quit Enigma, commit your changes, and make a pull request!
+
+## Generating a Mapped Jar
+
+To generate a mapped jar, simply run the `mapNamedJar` task. This task will build a deobfuscated jar with yarn mappings and automatically mapped fields (enums, etc.) - any unmapped names will be filled with intermediary names.
+
+This jar can be opened in any common class file viewer - such as your IDE - where you can view the methods, fields and classes with their names.
+
+
+
+


### PR DESCRIPTION
Looking for help with this! Im not so sure how to write the Enigma technical information as it would likely consist of many sections due to the wide array of features.

Essentially, this pull request closes #2 - cleans up and updates the various technical pages from the Fabric Wiki.

- Cleaned up Loom+Loader technical pages.
- Rewrote fabric.mod.json specification to be more concise and to the point (to be an actual specification reference)
- Cleaned up Tiny+Enigma Mapping Specs

Some other things:
- Maybe someone would be willing to make a page on Matcher or the Fabric Meta API? I would be happy to do the Fabric Meta API if no-one wants to.
- Feedback wanted for the fabric.mod.json spec!
- Feedback wanted for the yarn page, it's a bit barren at the minute!

## Tasks

- [ ] Enigma Technical Page
- [ ] Matcher Page (optional)
- [ ] Fabric Meta API Page
- [ ] Add information on the section to index.md