### PR TITLE
Use fork of markdown-snippet that fixes indents.

### DIFF
--- a/develop/events.md
+++ b/develop/events.md
@@ -57,7 +57,7 @@ We’ll be adding eggs to the coal ore loot table.
 
 Fabric API has an event that is fired when loot tables are loaded, `LootTableEvents.MODIFY`. You can register a callback for it in your mod initializer. Let’s also check that the current loot table is the coal ore loot table.
 
-@[code lang=java transclude={38-38}](@/reference/latest/src/main/java/com/example/docs/event/FabricDocsReferenceEvents.java)
+@[code lang=java transclude={38-40}](@/reference/latest/src/main/java/com/example/docs/event/FabricDocsReferenceEvents.java)
 
 #### Adding Items to the Loot Table
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "markdown-it-mathjax3": "^4.3.2",
-        "markdown-it-vuepress-code-snippet-enhanced": "^1.0.1",
+        "markdown-it-vuepress-code-snippet-enhanced": "github:IMB11/md-it-enhanced-snippets",
         "vitepress": "^1.0.0-rc.33",
         "vitepress-versioning-plugin": "^0.9.0",
         "vue": "^3.4.0"
@@ -1174,8 +1174,8 @@
     },
     "node_modules/markdown-it-vuepress-code-snippet-enhanced": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/markdown-it-vuepress-code-snippet-enhanced/-/markdown-it-vuepress-code-snippet-enhanced-1.0.1.tgz",
-      "integrity": "sha512-CfDWHyRWuNwvBIAQTXnlZVKRGxnOo82tnFrzxn2XLoI4jAK2mn1iNNQSyXB9ouxJKDn1YChHevnIG1woUi/g/g=="
+      "resolved": "git+ssh://git@github.com/IMB11/md-it-enhanced-snippets.git#dfb9fa25527b2f772d50ca37ae526484c890b8ae",
+      "license": "MIT"
     },
     "node_modules/mathjax-full": {
       "version": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "markdown-it-mathjax3": "^4.3.2",
-    "markdown-it-vuepress-code-snippet-enhanced": "github:IMB11/md-it-enhanced-snippets",
+    "markdown-it-vuepress-code-snippet-enhanced": "github:IMB11/md-it-enhanced-snippets#dfb9fa2"
     "vitepress": "^1.0.0-rc.33",
     "vitepress-versioning-plugin": "^0.9.0",
     "vue": "^3.4.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "markdown-it-mathjax3": "^4.3.2",
-    "markdown-it-vuepress-code-snippet-enhanced": "^1.0.1",
+    "markdown-it-vuepress-code-snippet-enhanced": "github:IMB11/md-it-enhanced-snippets",
     "vitepress": "^1.0.0-rc.33",
     "vitepress-versioning-plugin": "^0.9.0",
     "vue": "^3.4.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "markdown-it-mathjax3": "^4.3.2",
-    "markdown-it-vuepress-code-snippet-enhanced": "github:IMB11/md-it-enhanced-snippets#dfb9fa2"
+    "markdown-it-vuepress-code-snippet-enhanced": "github:IMB11/md-it-enhanced-snippets#dfb9fa2",
     "vitepress": "^1.0.0-rc.33",
     "vitepress-versioning-plugin": "^0.9.0",
     "vue": "^3.4.0"


### PR DESCRIPTION
Before+After
![image](https://github.com/FabricMC/fabric-docs/assets/93472213/1b9f5b13-f6c9-40d0-bc32-793045564684)
