### PR TITLE
Decrease the tab size for code blocks

### DIFF
--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -105,3 +105,8 @@ kbd {
   margin-left: auto;
   margin-right: auto;
 }
+
+/* Decrease the tab size for code blocks. */
+.vp-doc code {
+  tab-size: 2 !important;
+}


### PR DESCRIPTION
I was unable to do this without using `!important`, if you can please let me know :D