### PR TITLE
Fix i18n - deadlinks + use Intl instead.

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -43,6 +43,9 @@ export default defineVersionedConfig(__dirname, {
     ...loadLocales(__dirname)
   },
 
+  // Prevent dead links from being reported as errors - allows partially translated pages to be built.
+  ignoreDeadLinks: true,
+
   srcExclude: [
     "README.md",
     "LICENSE.md",

--- a/.vitepress/i18n.ts
+++ b/.vitepress/i18n.ts
@@ -79,7 +79,6 @@ export function loadLocales(_rootDir: string): LocaleConfig<DefaultTheme.Config>
   const locales: LocaleConfig<DefaultTheme.Config> = {};
 
   for (const folder of translatedFolders) {
-    console.log(folder);
     let firstHalf: string = folder.slice(0, 2);
     let secondHalf: string = folder.slice(3, 5);
 
@@ -91,8 +90,6 @@ export function loadLocales(_rootDir: string): LocaleConfig<DefaultTheme.Config>
       link: `/${folder}/`,
       lang: folder,
     }
-
-    console.log(locales);
   }
 
   return locales;

--- a/.vitepress/i18n.ts
+++ b/.vitepress/i18n.ts
@@ -83,10 +83,13 @@ export function loadLocales(_rootDir: string): LocaleConfig<DefaultTheme.Config>
     let secondHalf: string = folder.slice(3, 5);
 
     let locale = new Intl.DisplayNames([`${firstHalf}-${secondHalf.toUpperCase()}`], { type: 'language' });
-    let localeName = locale?.of(`${firstHalf}-${secondHalf.toUpperCase()}`);
+    let localeName = locale?.of(`${firstHalf}-${secondHalf.toUpperCase()}`)!;
+
+    // Capitalize the first letter of the locale name
+    localeName = localeName.charAt(0).toUpperCase() + localeName.slice(1);
 
     locales[folder] = {
-      label: localeName!,
+      label: localeName,
       link: `/${folder}/`,
       lang: folder,
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "inter": "^2.1.0",
+        "locale-codes": "^1.3.1",
         "markdown-it-mathjax3": "^4.3.2",
         "markdown-it-vuepress-code-snippet-enhanced": "github:IMB11/md-it-enhanced-snippets#dfb9fa2",
         "vitepress": "^1.0.0-rc.33",
@@ -1142,34 +1142,10 @@
         "node": ">=6"
       }
     },
-    "node_modules/async": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
-      "integrity": "sha512-XQJ3MipmCHAIBBMFfu2jaSetneOrXbSyyqeU3Nod867oNOpS+i9FEms5PWgjMxSgBybRf2IVVLtr1YfrDO+okg=="
-    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
-    },
-    "node_modules/camelcase": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha512-wzLkDa4K/mzI1OSITC+DUyjgIl/ETNHE9QvYgy6J6Jvqyyz4C0Xfd+lQhb19sX2jMpZV4IssUn0VDVmglV+s4g==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/chainsaw": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.0.9.tgz",
-      "integrity": "sha512-nG8PYH+/4xB+8zkV4G844EtfvZ5tTiLFoX3dZ4nhF4t3OCKIb9UvaFyNmeZO2zOSmRWzBoTD+napN6hiL+EgcA==",
-      "dependencies": {
-        "traverse": ">=0.3.0 <0.4"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/cheerio": {
       "version": "1.0.0-rc.10",
@@ -1204,38 +1180,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/cldr": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/cldr/-/cldr-3.5.0.tgz",
-      "integrity": "sha512-4whGBw4tQO6fueovGTiX7xjzio3KnV0n8cS8MxshLvDH3i9mNOQz3MFlXd4DOp7hIVHZEBJi17akgMb/7PR7zw==",
-      "dependencies": {
-        "memoizeasync": "0.8.0",
-        "passerror": "0.0.1",
-        "pegjs": "0.7.0",
-        "seq": "0.3.5",
-        "uglify-js": "1.3.3",
-        "underscore": "1.3.3",
-        "unicoderegexp": "0.4.1",
-        "xmldom": "0.1.19",
-        "xpath": "0.0.7"
-      }
-    },
-    "node_modules/cldr/node_modules/passerror": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/passerror/-/passerror-0.0.1.tgz",
-      "integrity": "sha512-fq8T/YCS8b1EwvhZPJQD2SURSyvVs2nPXk8EfAikcSeGhg+gL5524bcW9VCuz3hlQhXnPZWr02+3GbtTIFzf9A==",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/cldr/node_modules/underscore": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.3.3.tgz",
-      "integrity": "sha512-ddgUaY7xyrznJ0tbSUZgvNdv5qbiF6XcUBTrHgdCOVUrxJYWozD5KyiRjtIwds1reZ7O1iPLv5rIyqnVAcS6gg==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/cli-color": {
@@ -1299,14 +1243,6 @@
       "dependencies": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
-      }
-    },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/dom-serializer": {
@@ -1516,17 +1452,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/hashish": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/hashish/-/hashish-0.0.4.tgz",
-      "integrity": "sha512-xyD4XgslstNAs72ENaoFvgMwtv8xhiDtC2AtzCG+8yF7W/Knxxm9BX+e2s25mm+HxMKh0rBmXVOEGF3zNImXvA==",
-      "dependencies": {
-        "traverse": ">=0.2.4"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/hookable": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
@@ -1550,29 +1475,18 @@
         "entities": "^2.0.0"
       }
     },
-    "node_modules/inter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/inter/-/inter-2.1.0.tgz",
-      "integrity": "sha512-8cZSpFu2Kb3dc3jWnBdbJuZIXs7VScaFU1tqxHu/ue6em3oTpCrjAn4+smjWqvliycTb1x8JL5+HsTOeRtLhkA==",
-      "dependencies": {
-        "async": "0.9.0",
-        "cldr": "3.5.0",
-        "moment-timezone": "^0.5.40",
-        "passerror": "1.1.0",
-        "seq": "=0.3.5",
-        "uglify-js": "1.3.3",
-        "uglifyast": "0.2.1",
-        "underscore": "1.8.3",
-        "yargs": "3.7.2"
-      },
-      "bin": {
-        "buildInter": "bin/buildInter"
-      }
-    },
     "node_modules/is-promise": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
+    },
+    "node_modules/iso639-codes": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/iso639-codes/-/iso639-codes-1.0.1.tgz",
+      "integrity": "sha512-jdTSv8yn6D7GODDrRtuWG7y3du3aoa+ki5H8h/Y48/NleNAd7Fw/M2niTTLXGH4QnqhJ98hg1JMQtP9csQ31Lg==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -1603,15 +1517,28 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/langs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/langs/-/langs-2.0.0.tgz",
+      "integrity": "sha512-v4pxOBEQVN1WBTfB1crhTtxzNLZU9HPWgadlwzWKISJtt6Ku/CnpBrwVy+jFv8StjxsPfwPFzO0CMwdZLJ0/BA=="
+    },
+    "node_modules/locale-codes": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/locale-codes/-/locale-codes-1.3.1.tgz",
+      "integrity": "sha512-C7fxGkU4jAuHqavtKj4IhSD2yPEzChFMRfNHjzwIAz9JTbYHtBJDcQQgmJDezBogk9/vvgS7chKMhpVEKavk5A==",
+      "dependencies": {
+        "iso639-codes": "^1.0.1",
+        "langs": "^2.0.0",
+        "windows-locale": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "node_modules/lru-cache": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
-      "integrity": "sha512-dVmQmXPBlTgFw77hm60ud//l2bCuDKkqC2on1EBoM7s9Urm9IQDrnujwZ93NFnAq0dVZ0HBXTS7PwEG+YE7+EQ=="
     },
     "node_modules/lru-queue": {
       "version": "0.1.0",
@@ -1660,23 +1587,6 @@
         "mhchemparser": "^4.1.0",
         "mj-context-menu": "^0.6.1",
         "speech-rule-engine": "^4.0.6"
-      }
-    },
-    "node_modules/memoizeasync": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/memoizeasync/-/memoizeasync-0.8.0.tgz",
-      "integrity": "sha512-2lqfGQNyxpKPMUrowJKEt/1xPFhEU+pPFYlS9/dyGUSOttMgn4Yh82DfMvXu40nmTjjm++o4glPMJML//eXGIQ==",
-      "dependencies": {
-        "lru-cache": "2.5.0",
-        "passerror": "0.0.2"
-      }
-    },
-    "node_modules/memoizeasync/node_modules/passerror": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/passerror/-/passerror-0.0.2.tgz",
-      "integrity": "sha512-vMAu62amXQNrgTZoZagcnj63atr0y/2WNYIhAoRarQOsfEDhu+xYoPT85lK18MEMUnGHpUrIrb+DHMOq8c5HDA==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/memoizee": {
@@ -1729,25 +1639,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.6.1.tgz",
       "integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA=="
-    },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/moment-timezone": {
-      "version": "0.5.45",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.45.tgz",
-      "integrity": "sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==",
-      "dependencies": {
-        "moment": "^2.29.4"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/mrmime": {
       "version": "2.0.0",
@@ -1820,25 +1711,6 @@
       "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
       "dependencies": {
         "parse5": "^6.0.1"
-      }
-    },
-    "node_modules/passerror": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/passerror/-/passerror-1.1.0.tgz",
-      "integrity": "sha512-0NQONjhhED7/5Uu7V5BX5WFYPXBRpDS/zDDM90mguEizmwrbs3idSs3QhzLx0Kz6ZBLNVAiZEzc+slOaHrN2zQ==",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/pegjs": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.7.0.tgz",
-      "integrity": "sha512-LKb5vROzG2N6FVpITS8zy4BSB8M5z8JgiM0LzgvUVRIdScHys8RYlYvHVSL3WeXMLowF9MZj1hPusuVvTgeq4w==",
-      "bin": {
-        "pegjs": "bin/pegjs"
-      },
-      "engines": {
-        "node": ">= 0.6.6"
       }
     },
     "node_modules/perfect-debounce": {
@@ -1941,18 +1813,6 @@
       "integrity": "sha512-Orrsjf9trHHxFRuo9/rzm0KIWmgzE8RMlZMzuhZOJ01Rnz3D0YBAe+V6473t6/H6c7irs6Lt48brULAiRWb3Vw==",
       "peer": true
     },
-    "node_modules/seq": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/seq/-/seq-0.3.5.tgz",
-      "integrity": "sha512-sisY2Ln1fj43KBkRtXkesnRHYNdswIkIibvNe/0UKm2GZxjMbqmccpiatoKr/k2qX5VKiLU8xm+tz/74LAho4g==",
-      "dependencies": {
-        "chainsaw": ">=0.0.7 <0.1",
-        "hashish": ">=0.0.2 <0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/shiki": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.1.1.tgz",
@@ -2046,14 +1906,6 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
-    "node_modules/traverse": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
@@ -2064,51 +1916,11 @@
       "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
       "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
     },
-    "node_modules/uglify-js": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.3.3.tgz",
-      "integrity": "sha512-rM1jYODSisv6Ki54DTEec2YvPv11LAdFVLgrY8fqGzwTDrg1tT91Z8nExx0X375TOptjwJh9MSs6KYQez8XCoQ==",
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/uglifyast": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/uglifyast/-/uglifyast-0.2.1.tgz",
-      "integrity": "sha512-iCjmXhIvNls8IWA0WsperxT3GNTv3tG0m5HcG7ltERWqutbJ7jAQMBD4l47RpQ/qbrQFwhc6LuNzabQEh6e1Sw==",
-      "dependencies": {
-        "uglify-js": "=1.3.2"
-      }
-    },
-    "node_modules/uglifyast/node_modules/uglify-js": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.3.2.tgz",
-      "integrity": "sha512-XYXlIZ36VB2vS/dKULYHhwgCY3zxGE3Ht+eBrzqVbG3I9NTeb3pP82lNSjK/fdkLFw8fYuZER1/urmeI04jWLg==",
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha512-5WsVTFcH1ut/kkhAaHf4PVgI8c7++GiVcpCGxPouI6ZVjsqPnSDf8h/8HtVqc0t4fzRXwnMK70EcZeAs3PIddg=="
-    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "devOptional": true
-    },
-    "node_modules/unicoderegexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/unicoderegexp/-/unicoderegexp-0.4.1.tgz",
-      "integrity": "sha512-ydh8D5mdd2ldTS25GtZJEgLciuF0Qf2n3rwPhonELk3HioX201ClYGvZMc1bCmx6nblZiADQwbMWekeIqs51qw=="
     },
     "node_modules/valid-data-url": {
       "version": "3.0.1",
@@ -2347,29 +2159,12 @@
       "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
       "integrity": "sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw=="
     },
-    "node_modules/window-size": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha512-1pTPQDKTdd61ozlKGNCjhNRd+KPmgLSGa3mZTHoOliaGcESD8G1PXhh7c1fgiPjVbNVfgy2Faw4BI8/m0cC8Mg==",
+    "node_modules/windows-locale": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/windows-locale/-/windows-locale-1.1.3.tgz",
+      "integrity": "sha512-0OlMOPNGj7GTB6C7WmqS3o4eydjnoYj0uwot2KJf7E0JUucwYwzkcvCWQwnuOV60WqDMeGJpSankgveNMj5r0g==",
       "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/wordwrap": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-      "integrity": "sha512-xSBsCeh+g+dinoBv3GAOWM4LcVVO68wLXRanibtBSdUvkGWQRGeE9P7IwU9EmDDi4jA6L44lz15CGMwdw9N5+Q==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/xmldom": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz",
-      "integrity": "sha512-pDyxjQSFQgNHkU+yjvoF+GXVGJU7e9EnOg/KcGMDihBIKjTsOeDYaECwC/O9bsUWKY+Sd9izfE43JXC46EOHKA==",
-      "deprecated": "Deprecated due to CVE-2021-21366 resolved in 0.5.0",
-      "engines": {
-        "node": ">=0.1"
+        "node": ">=v10.24.1"
       }
     },
     "node_modules/xmldom-sre": {
@@ -2378,25 +2173,6 @@
       "integrity": "sha512-f9s+fUkX04BxQf+7mMWAp5zk61pciie+fFLC9hX9UVvCeJQfNHRHXpeo5MPcR0EUf57PYLdt+ZO4f3Ipk2oZUw==",
       "engines": {
         "node": ">=0.1"
-      }
-    },
-    "node_modules/xpath": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.7.tgz",
-      "integrity": "sha512-wRXmsfZWSMAPpbvNT42NF6gnQsouCzHZlZikbo0V2bgQsrUm/rhPVeQphsywyOLr8xBA2PuC8VIw0A6hQMHN+g==",
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
-    "node_modules/yargs": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.7.2.tgz",
-      "integrity": "sha512-tekp+l+MFb/mdZOWq7fIMugv6kpbrU3Lo1dCdX07teodernEmzw/wzXs+K3oEnbmoyXlGJ9+QpvMI+5//2uz2A==",
-      "dependencies": {
-        "camelcase": "^1.0.2",
-        "decamelize": "^1.0.0",
-        "window-size": "0.1.0",
-        "wordwrap": "0.0.2"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "packages": {
     "": {
       "dependencies": {
-        "locale-codes": "^1.3.1",
         "markdown-it-mathjax3": "^4.3.2",
         "markdown-it-vuepress-code-snippet-enhanced": "github:IMB11/md-it-enhanced-snippets#dfb9fa2",
         "vitepress": "^1.0.0-rc.33",
@@ -1480,14 +1479,6 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
     },
-    "node_modules/iso639-codes": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/iso639-codes/-/iso639-codes-1.0.1.tgz",
-      "integrity": "sha512-jdTSv8yn6D7GODDrRtuWG7y3du3aoa+ki5H8h/Y48/NleNAd7Fw/M2niTTLXGH4QnqhJ98hg1JMQtP9csQ31Lg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -1515,24 +1506,6 @@
       },
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/langs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/langs/-/langs-2.0.0.tgz",
-      "integrity": "sha512-v4pxOBEQVN1WBTfB1crhTtxzNLZU9HPWgadlwzWKISJtt6Ku/CnpBrwVy+jFv8StjxsPfwPFzO0CMwdZLJ0/BA=="
-    },
-    "node_modules/locale-codes": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/locale-codes/-/locale-codes-1.3.1.tgz",
-      "integrity": "sha512-C7fxGkU4jAuHqavtKj4IhSD2yPEzChFMRfNHjzwIAz9JTbYHtBJDcQQgmJDezBogk9/vvgS7chKMhpVEKavk5A==",
-      "dependencies": {
-        "iso639-codes": "^1.0.1",
-        "langs": "^2.0.0",
-        "windows-locale": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/lodash": {
@@ -2158,14 +2131,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
       "integrity": "sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw=="
-    },
-    "node_modules/windows-locale": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/windows-locale/-/windows-locale-1.1.3.tgz",
-      "integrity": "sha512-0OlMOPNGj7GTB6C7WmqS3o4eydjnoYj0uwot2KJf7E0JUucwYwzkcvCWQwnuOV60WqDMeGJpSankgveNMj5r0g==",
-      "engines": {
-        "node": ">=v10.24.1"
-      }
     },
     "node_modules/xmldom-sre": {
       "version": "0.1.31",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "@rollup/rollup-linux-x64-gnu": "4.6.1"
   },
   "dependencies": {
-    "locale-codes": "^1.3.1",
     "markdown-it-mathjax3": "^4.3.2",
     "markdown-it-vuepress-code-snippet-enhanced": "github:IMB11/md-it-enhanced-snippets#dfb9fa2",
     "vitepress": "^1.0.0-rc.33",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@rollup/rollup-linux-x64-gnu": "4.6.1"
   },
   "dependencies": {
-    "inter": "^2.1.0",
+    "locale-codes": "^1.3.1",
     "markdown-it-mathjax3": "^4.3.2",
     "markdown-it-vuepress-code-snippet-enhanced": "github:IMB11/md-it-enhanced-snippets#dfb9fa2",
     "vitepress": "^1.0.0-rc.33",


### PR DESCRIPTION
Turns out Intl worked with four letter codes if you used `language` instead of `region`. Added dead link option to allow partially translated pages to be built, and fallback to the english sidebar if a language has no sidebar file yet.