### PR TITLE
Change Identifier constructor to Identifier.of()

### DIFF
--- a/reference/latest/src/client/java/com/example/docs/rendering/DrawContextExampleScreen.java
+++ b/reference/latest/src/client/java/com/example/docs/rendering/DrawContextExampleScreen.java
@@ -55,13 +55,13 @@ public class DrawContextExampleScreen extends Screen {
 		// :::4
 
 		// :::5
-		Identifier texture = new Identifier("minecraft", "textures/block/deepslate.png");
+		Identifier texture = Identifier.of("minecraft", "textures/block/deepslate.png");
 		// texture, x, y, u, v, width, height, textureWidth, textureHeight
 		context.drawTexture(texture, 90, 90, 0, 0, 16, 16, 16, 16);
 		// :::5
 
 		// :::6
-		Identifier texture2 = new Identifier("fabric-docs-reference", "textures/gui/test-uv-drawing.png");
+		Identifier texture2 = Identifier.of("fabric-docs-reference", "textures/gui/test-uv-drawing.png");
 		int u = 10, v = 13, regionWidth = 14, regionHeight = 14;
 		// texture, x, y, width, height, u, v, regionWidth, regionHeight, textureWidth, textureHeight
 		context.drawTexture(texture2, 90, 190, 14, 14, u, v, regionWidth, regionHeight, 256, 256);


### PR DESCRIPTION
Minecraft has privatised the constructors of net.minecraft.util.Identifier in 1.21, have to use Identifier.of() instead