### PR TITLE
Recursive codecs name change

### DIFF
--- a/develop/codecs.md
+++ b/develop/codecs.md
@@ -411,7 +411,7 @@ Our new codec will serialize beans to json like this, grabbing only fields that 
 
 ### Recursive Codecs {#recursive-codecs}
 
-Sometimes it is useful to have a codec that uses _itself_ to decode specific fields, for example when dealing with certain recursive data structures. In vanilla code, this is used for `Text` objects, which may store other `Text`s as children. Such a codec can be constructed using `Codecs#createRecursive`.
+Sometimes it is useful to have a codec that uses _itself_ to decode specific fields, for example when dealing with certain recursive data structures. In vanilla code, this is used for `Text` objects, which may store other `Text`s as children. Such a codec can be constructed using `Codec#recursive`.
 
 For example, let's try to serialize a singly-linked list. This way of representing lists consists of a bunch of nodes that hold both a value and a reference to the next node in the list. The list is then represented by its first node, and traversing the list is done by following the next node until none remain. Here is a simple implementation of nodes that store integers.
 
@@ -419,10 +419,10 @@ For example, let's try to serialize a singly-linked list. This way of representi
 public record ListNode(int value, ListNode next) {}
 ```
 
-We can't construct a codec for this by ordinary means, because what codec would we use for the `next` field? We would need a `Codec<ListNode>`, which is what we are in the middle of constructing! `Codecs#createRecursive` lets us achieve that using a magic-looking lambda:
+We can't construct a codec for this by ordinary means, because what codec would we use for the `next` field? We would need a `Codec<ListNode>`, which is what we are in the middle of constructing! `Codec#recursive` lets us achieve that using a magic-looking lambda:
 
 ```java
-Codec<ListNode> codec = Codecs.createRecursive(
+Codec<ListNode> codec = Codec.recursive(
   "ListNode", // a name for the codec
   selfCodec -> {
     // Here, `selfCodec` represents the `Codec<ListNode>`, as if it was already constructed

--- a/translated/de_de/develop/codecs.md
+++ b/translated/de_de/develop/codecs.md
@@ -351,7 +351,7 @@ Unser neuer Codec serialisiert Bohnen zu JSON und erfasst dabei nur die Felder, 
 
 ### Rekursive Codecs
 
-Manchmal ist es nützlich, einen Codec zu haben, der _sich selbst_ verwendet, um bestimmte Felder zu dekodieren, zum Beispiel wenn es um bestimmte rekursive Datenstrukturen geht. Im Vanilla-Code wird dies für `Text`-Objekte verwendet, die andere `Text`e als Kinder speichern können. Ein solcher Codec kann mit `Codecs#createRecursive` erstellt werden.
+Manchmal ist es nützlich, einen Codec zu haben, der _sich selbst_ verwendet, um bestimmte Felder zu dekodieren, zum Beispiel wenn es um bestimmte rekursive Datenstrukturen geht. Im Vanilla-Code wird dies für `Text`-Objekte verwendet, die andere `Text`e als Kinder speichern können. Ein solcher Codec kann mit `Codec#recursive` erstellt werden.
 
 Versuchen wir zum Beispiel, eine einfach verknüpfte Liste zu serialisieren. Diese Art der Darstellung von Listen besteht aus einem Bündel von Knoten, die sowohl einen Wert als auch einen Verweis auf den nächsten Knoten in der Liste enthalten. Die Liste wird dann durch ihren ersten Knoten repräsentiert, und das Durchlaufen der Liste erfolgt durch Verfolgen des nächsten Knotens, bis keiner mehr übrig ist. Hier ist eine einfache Implementierung von Knoten, die ganze Zahlen speichern.
 
@@ -359,10 +359,10 @@ Versuchen wir zum Beispiel, eine einfach verknüpfte Liste zu serialisieren. Die
 public record ListNode(int value, ListNode next) {}
 ```
 
-Wir können dafür keinen Codec mit normalen Mitteln konstruieren, denn welchen Codec würden wir für das Attribut `next` verwenden? Wir bräuchten einen `Codec<ListNode>`, und den sind wir gerade dabei zu konstruieren! Mit `Codecs#createRecursive` können wir das mit einem magisch aussehenden Lambda erreichen:
+Wir können dafür keinen Codec mit normalen Mitteln konstruieren, denn welchen Codec würden wir für das Attribut `next` verwenden? Wir bräuchten einen `Codec<ListNode>`, und den sind wir gerade dabei zu konstruieren! Mit `Codec#recursive` können wir das mit einem magisch aussehenden Lambda erreichen:
 
 ```java
-Codec<ListNode> codec = Codecs.createRecursive(
+Codec<ListNode> codec = Codec.recursive(
   "ListNode", // Ein Name für den Codec
   selfCodec -> {
     // Hier repräsentiert `selfCodec` den `Codec<ListNode>`, als ob er bereits konstruiert wäre

--- a/translated/es_es/develop/codecs.md
+++ b/translated/es_es/develop/codecs.md
@@ -350,7 +350,7 @@ Nuestro nuevo codec serializará beans a json de esta manera, usando solo los ca
 
 ### Codecs Recursivos
 
-A veces es útil tener un codec que se use a _sí mismo_ para decodificar ciertos miembros, por ejemplo cuando estamos lidiando con ciertas estructuras de datos recursivas. En el código vanilla, esto es usado para objetos `Text` (Texto), los cuales tienen otros objetos `Text` como hijos. Tal codec puede ser construido usando `Codecs#createRecursive`.
+A veces es útil tener un codec que se use a _sí mismo_ para decodificar ciertos miembros, por ejemplo cuando estamos lidiando con ciertas estructuras de datos recursivas. En el código vanilla, esto es usado para objetos `Text` (Texto), los cuales tienen otros objetos `Text` como hijos. Tal codec puede ser construido usando `Codec#recursive`.
 
 Por ejemplo, tratemos de serializar una lista enlazada. Esta manera de representar listas consiste en varios nodos que contienen un valor y una referencia al siguiente nodo en la lista. La lista es entonces representada mediante el primer nodo, y para caminar por la lista se sigue el siguiente nodo hasta que no quede ninguno. Aquí está una implementación simple de los nodos que guardan números enteros.
 
@@ -358,10 +358,10 @@ Por ejemplo, tratemos de serializar una lista enlazada. Esta manera de represent
 public record ListNode(int value, ListNode next) {}
 ```
 
-No podemos construir un codec para esto mediante métodos ordinarios, porque ¿qué codec usaríamos para el miembro de `next`? ¡Tendríamos que usar un `Codec<ListNode>`, que es lo que estamos construyendo actualmente! `Codecs#createRecursive` nos permite lograr eso con una expresión lambda mágica:
+No podemos construir un codec para esto mediante métodos ordinarios, porque ¿qué codec usaríamos para el miembro de `next`? ¡Tendríamos que usar un `Codec<ListNode>`, que es lo que estamos construyendo actualmente! `Codec#recursive` nos permite lograr eso con una expresión lambda mágica:
 
 ```java
-Codec<ListNode> codec = Codecs.createRecursive(
+Codec<ListNode> codec = Codec.recursive(
   "ListNode", // a name for the codec
   selfCodec -> {
     // Here, `selfCodec` represents the `Codec<ListNode>`, as if it was already constructed

--- a/translated/fr_fr/develop/codecs.md
+++ b/translated/fr_fr/develop/codecs.md
@@ -349,7 +349,7 @@ Notre nouveau codec sérialisera les beans en JSON ainsi, en n'utilisant que les
 
 ### Codecs récursifs
 
-Il est parfois utile d'avoir un codec qui s'utilise _soi-même_ pour décoder certains champs, par exemple avec certaines structures de données récursives. Le code vanilla en fait usage pour les objets `Text`, qui peuvent stocker d'autres `Text`s en tant qu'enfants. Un tel codec peut être construit grâce à `Codecs#createRecursive`.
+Il est parfois utile d'avoir un codec qui s'utilise _soi-même_ pour décoder certains champs, par exemple avec certaines structures de données récursives. Le code vanilla en fait usage pour les objets `Text`, qui peuvent stocker d'autres `Text`s en tant qu'enfants. Un tel codec peut être construit grâce à `Codec#recursive`.
 
 À titre d'exemple, essayons de sérialiser une liste simplement chaînée. Cette manière de représenter une liste consiste en des nœuds qui contiennent et une valeur, et une référence au prochain nœud de la liste. La liste est alors représentée par son premier nœud, et pour la parcourir, il suffit de continuer à regarder le nœud suivant juste qu'à ce qu'il n'en existe plus. Voici une implémentation simple de nœuds qui stockent des entiers.
 
@@ -357,10 +357,10 @@ Il est parfois utile d'avoir un codec qui s'utilise _soi-même_ pour décoder ce
 public record ListNode(int value, ListNode next) {}
 ```
 
-Il est impossible de construire un codec comme d'habitude, puisque quel codec utiliserait-on pour le champ `next` ? Il faudrait un `Codec<ListNode>`, ce qui est précisément ce qu'on veut obtenir ! `Codecs#createRecursive` permet de le faire au moyen d'un lambda magique en apparence :
+Il est impossible de construire un codec comme d'habitude, puisque quel codec utiliserait-on pour le champ `next` ? Il faudrait un `Codec<ListNode>`, ce qui est précisément ce qu'on veut obtenir ! `Codec#recursive` permet de le faire au moyen d'un lambda magique en apparence :
 
 ```java
-Codec<ListNode> codec = Codecs.createRecursive(
+Codec<ListNode> codec = Codec.recursive(
   "ListNode", // un nom pour le codec
   selfCodec -> {
     // Ici, `selfCodec` représente le `Codec<ListNode>`, comme s'il était déjà construit

--- a/translated/it_it/develop/codecs.md
+++ b/translated/it_it/develop/codecs.md
@@ -350,7 +350,7 @@ Il nostro nuovo codec serializzerà fagioli a json così, prendendo solo attribu
 
 ### Codec Ricorsivi
 
-A volte è utile avere un codec che utilizza _sé stesso_ per decodificare attributi specifici, per esempio quando si gestiscono certe strutture dati ricorsive. Nel codice vanilla, questo è usato per gli oggetti `Text`, che potrebbero contenere altri `Text` come figli. Un codec del genere può essere costruito usando `Codecs#createRecursive`.
+A volte è utile avere un codec che utilizza _sé stesso_ per decodificare attributi specifici, per esempio quando si gestiscono certe strutture dati ricorsive. Nel codice vanilla, questo è usato per gli oggetti `Text`, che potrebbero contenere altri `Text` come figli. Un codec del genere può essere costruito usando `Codec#recursive`.
 
 Per esempio, proviamo a serializzare una lista concatenata singolarmente. Questo metodo di rappresentare le liste consiste di una serie di nodi che contengono sia un valore sia un riferimento al nodo successivo nella lista. La lista è poi rappresentata dal suo primo nodo, e per attraversare la lista si segue il prossimo nodo finché non ce ne sono più. Ecco una semplice implementazione di nodi che contengono interi.
 
@@ -358,10 +358,10 @@ Per esempio, proviamo a serializzare una lista concatenata singolarmente. Questo
 public record ListNode(int value, ListNode next) {}
 ```
 
-Non possiamo costruire un codec per questo come si fa di solito: quale codec useremmo per l'attributo `next`? Avremmo bisogno di un `Codec<ListNode>`, che è ciò che stiamo costruendo proprio ora! `Codecs#createRecursive` ci permette di fare ciò usando una lambda che sembra magia:
+Non possiamo costruire un codec per questo come si fa di solito: quale codec useremmo per l'attributo `next`? Avremmo bisogno di un `Codec<ListNode>`, che è ciò che stiamo costruendo proprio ora! `Codec#recursive` ci permette di fare ciò usando una lambda che sembra magia:
 
 ```java
-Codec<ListNode> codec = Codecs.createRecursive(
+Codec<ListNode> codec = Codec.recursive(
   "ListNode", // un nome per il codec
   selfCodec -> {
     // Qui, `selfCodec` rappresenta il `Codec<ListNode>`, come se fosse già costruito

--- a/translated/zh_cn/develop/codecs.md
+++ b/translated/zh_cn/develop/codecs.md
@@ -352,7 +352,7 @@ Codec<Bean> beanCodec = beanTypeCodec.dispatch("type", Bean::getType, BeanType::
 
 ### 递归Codec
 
-有时，使用自身来解码特定字段的Codec很有用，例如在处理某些递归数据结构时。 在原始代码中，这用于`Text`对象，它可以将其他`Text`存储为子对象。 可以使用`Codecs#createRecursive`构建这样的Codec。 在原版代码中，这用于 `Text` 对象，可能会存储其他的 `Text` 作为子对象。 可以使用 `Codecs#createRecursive` 构建这样的 codec。
+有时，使用自身来解码特定字段的Codec很有用，例如在处理某些递归数据结构时。 在原始代码中，这用于`Text`对象，它可以将其他`Text`存储为子对象。 可以使用`Codec#recursive`构建这样的Codec。 在原版代码中，这用于 `Text` 对象，可能会存储其他的 `Text` 作为子对象。 可以使用 `Codec#recursive` 构建这样的 codec。
 
 例如，让我们尝试序列化单链列表。 列表是由一组节点的表示的，这些节点既包含一个值，也包含对列表中下一个节点的引用。 然后列表由其第一个节点表示，遍历列表是通过跟随下一个节点来完成的，直到没有剩余节点。 以下是存储整数的节点的简单实现。
 
@@ -360,10 +360,10 @@ Codec<Bean> beanCodec = beanTypeCodec.dispatch("type", Bean::getType, BeanType::
 public record ListNode(int value, ListNode next) {}
 ```
 
-我们无法通过普通方法为此构建codec，因为我们会对`next`字段使用什么codec？ 我们需要一个`Codec<ListNode>`，这就是我们正在构建的！ `Codecs#createRecursive` 让我们使用一个神奇的 lambda 来实现这一点： 我们需要一个 `Codec<ListNode>`，这就是我们还在构建的！ 序列化与反序列化
+我们无法通过普通方法为此构建codec，因为我们会对`next`字段使用什么codec？ 我们需要一个`Codec<ListNode>`，这就是我们正在构建的！ `Codec#recursive` 让我们使用一个神奇的 lambda 来实现这一点： 我们需要一个 `Codec<ListNode>`，这就是我们还在构建的！ 序列化与反序列化
 
 ```java
-Codec<ListNode> codec = Codecs.createRecursive(
+Codec<ListNode> codec = Codec.recursive(
   "ListNode", // codec的名称
   selfCodec -> {
     // 这里，`selfCodec` 代表 `Codec<ListNode>`，就像它已经构造好了一样


### PR DESCRIPTION
``Codecs#createRecursive`` does not exist anymore, and has been replaced with ``Codec#recurisve``. Not sure when this change exactly occurred on the Minecraft Codebase, however I have updated the docs to reflect this.

All instances of ``Codecs#createRecursive`` have been replaced with ``Codec#recurisve``, along with instances in any code examples. The usage of these functions is the same, so no extra changes were required. Additionally, I made sure not to update any 1.20.4 articles, as this was probably correct at the time.