### PR TITLE
Fix typo in 'GUIDIE'

### DIFF
--- a/reference/latest/src/main/java/com/example/docs/item/ModItems.java
+++ b/reference/latest/src/main/java/com/example/docs/item/ModItems.java
@@ -30,10 +30,10 @@ public class ModItems {
 	// :::1
 
 	// :::6
-	public static final Item GUIDITE_HELMET = register(new ArmorItem(ModArmorMaterials.GUIDIE, ArmorItem.Type.HELMET, new Item.Settings()), "guidite_helmet");
-	public static final Item GUIDITE_BOOTS = register(new ArmorItem(ModArmorMaterials.GUIDIE, ArmorItem.Type.BOOTS, new Item.Settings()), "guidite_boots");
-	public static final Item GUIDITE_LEGGINGS = register(new ArmorItem(ModArmorMaterials.GUIDIE, ArmorItem.Type.LEGGINGS, new Item.Settings()), "guidite_leggings");
-	public static final Item GUIDITE_CHESTPLATE = register(new ArmorItem(ModArmorMaterials.GUIDIE, ArmorItem.Type.CHESTPLATE, new Item.Settings()), "guidite_chestplate");
+	public static final Item GUIDITE_HELMET = register(new ArmorItem(ModArmorMaterials.GUIDITE, ArmorItem.Type.HELMET, new Item.Settings()), "guidite_helmet");
+	public static final Item GUIDITE_BOOTS = register(new ArmorItem(ModArmorMaterials.GUIDITE, ArmorItem.Type.BOOTS, new Item.Settings()), "guidite_boots");
+	public static final Item GUIDITE_LEGGINGS = register(new ArmorItem(ModArmorMaterials.GUIDITE, ArmorItem.Type.LEGGINGS, new Item.Settings()), "guidite_leggings");
+	public static final Item GUIDITE_CHESTPLATE = register(new ArmorItem(ModArmorMaterials.GUIDITE, ArmorItem.Type.CHESTPLATE, new Item.Settings()), "guidite_chestplate");
 	// :::6
 	public static final Item LIGHTNING_STICK = register(new LightningStick(new Item.Settings()), "lightning_stick");
 	// :::7

--- a/reference/latest/src/main/java/com/example/docs/item/armor/ModArmorMaterials.java
+++ b/reference/latest/src/main/java/com/example/docs/item/armor/ModArmorMaterials.java
@@ -19,7 +19,7 @@ import com.example.docs.item.ModItems;
 
 public class ModArmorMaterials {
 	// :::2
-	public static final RegistryEntry<ArmorMaterial> GUIDIE = registerMaterial("guidite",
+	public static final RegistryEntry<ArmorMaterial> GUIDITE = registerMaterial("guidite",
 			// Defense (protection) point values for each armor piece.
 			Map.of(
 				ArmorItem.Type.HELMET, 3,


### PR DESCRIPTION
Renamed the variable 'GUIDIE' to 'GUIDITE' in the armor material registration.