### PR TITLE
improve order for ModItems tutorial

### DIFF
--- a/reference/latest/src/main/java/com/example/docs/item/ModItems.java
+++ b/reference/latest/src/main/java/com/example/docs/item/ModItems.java
@@ -31,9 +31,9 @@ public class ModItems {
 
 	// :::6
 	public static final Item GUIDITE_HELMET = register(new ArmorItem(ModArmorMaterials.GUIDITE, ArmorItem.Type.HELMET, new Item.Settings()), "guidite_helmet");
-	public static final Item GUIDITE_BOOTS = register(new ArmorItem(ModArmorMaterials.GUIDITE, ArmorItem.Type.BOOTS, new Item.Settings()), "guidite_boots");
-	public static final Item GUIDITE_LEGGINGS = register(new ArmorItem(ModArmorMaterials.GUIDITE, ArmorItem.Type.LEGGINGS, new Item.Settings()), "guidite_leggings");
 	public static final Item GUIDITE_CHESTPLATE = register(new ArmorItem(ModArmorMaterials.GUIDITE, ArmorItem.Type.CHESTPLATE, new Item.Settings()), "guidite_chestplate");
+	public static final Item GUIDITE_LEGGINGS = register(new ArmorItem(ModArmorMaterials.GUIDITE, ArmorItem.Type.LEGGINGS, new Item.Settings()), "guidite_leggings");
+	public static final Item GUIDITE_BOOTS = register(new ArmorItem(ModArmorMaterials.GUIDITE, ArmorItem.Type.BOOTS, new Item.Settings()), "guidite_boots");
 	// :::6
 	public static final Item LIGHTNING_STICK = register(new LightningStick(new Item.Settings()), "lightning_stick");
 	// :::7


### PR DESCRIPTION
I changed the order of the armor items to match the order displayed in the 'Creative' mode:

- Helmet
- Chestplate
- Leggings
- Boots

to improve overall consistency.

![Capture d’écran 2024-07-10 à 11 34 11](https://github.com/FabricMC/fabric-docs/assets/7428736/1003fd50-3ec7-45d0-96ba-df0f09b3dbc6)
