### PR TITLE
Fix indentation for ModArmorMaterials.java

### DIFF
--- a/reference/latest/src/main/java/com/example/docs/item/armor/ModArmorMaterials.java
+++ b/reference/latest/src/main/java/com/example/docs/item/armor/ModArmorMaterials.java
@@ -43,11 +43,11 @@ public class ModArmorMaterials {
 	public static RegistryEntry<ArmorMaterial> registerMaterial(String id, Map<ArmorItem.Type, Integer> defensePoints, int enchantability, RegistryEntry<SoundEvent> equipSound, Supplier<Ingredient> repairIngredientSupplier, float toughness, float knockbackResistance, boolean dyeable) {
 		// Get the supported layers for the armor material
 		List<ArmorMaterial.Layer> layers = List.of(
-				// The ID of the texture layer, the suffix, and whether the layer is dyeable.
-				// We can just pass the armor material ID as the texture layer ID.
-				// We have no need for a suffix, so we'll pass an empty string.
-				// We'll pass the dyeable boolean we received as the dyeable parameter.
-				new ArmorMaterial.Layer(Identifier.of(FabricDocsReference.MOD_ID, id), "", dyeable)
+			// The ID of the texture layer, the suffix, and whether the layer is dyeable.
+			// We can just pass the armor material ID as the texture layer ID.
+			// We have no need for a suffix, so we'll pass an empty string.
+			// We'll pass the dyeable boolean we received as the dyeable parameter.
+			new ArmorMaterial.Layer(Identifier.of(FabricDocsReference.MOD_ID, id), "", dyeable)
 		);
 
 		ArmorMaterial material = new ArmorMaterial(defensePoints, enchantability, equipSound, repairIngredientSupplier, layers, toughness, knockbackResistance);


### PR DESCRIPTION
In the tutorial, it looks weird:


before: 
![Capture d’écran 2024-07-10 à 11 39 54](https://github.com/FabricMC/fabric-docs/assets/7428736/ce5f32e3-b4d6-403d-83c2-3f35de9bd9c7)

after:
![Capture d’écran 2024-07-10 à 11 56 31](https://github.com/FabricMC/fabric-docs/assets/7428736/3a607768-8817-4155-a331-b5572a1a463f)

