### PR TITLE
Fix armor items for 1.21

### DIFF
--- a/develop/items/custom-armor.md
+++ b/develop/items/custom-armor.md
@@ -95,11 +95,11 @@ Obviously, an armor set doesn't need every type to be satisfied, you can have a 
 
 ### Durability {#durability}
 
-Unlike `ToolMaterial`, `ArmorMaterial` doesn't store any information about the durability of items.
-For this reason the durability needs to be added to the armor items' `Item.Settings` when registering them.
+Unlike `ToolMaterial`, `ArmorMaterial` does not store any information about the durability of items.
+For this reason the durability needs to be manually added to the armor items' `Item.Settings` when registering them.
 
 This is achieved using the `maxDamage` method in the `Item.Settings` class.
-The different armor slots have different base durabilities which are commonly multiplied by a shared armor material multiplier to set the durability but hard-coded values can also be used.
+The different armor slots have different base durabilities which are commonly multiplied by a shared armor material multiplier but hard-coded values can also be used.
 
 For the Guidite armor we'll be using a shared armor multiplier stored alongside the armor material:
 

--- a/develop/items/custom-armor.md
+++ b/develop/items/custom-armor.md
@@ -93,6 +93,20 @@ Now that you've registered the material, you can create the armor items in your 
 
 Obviously, an armor set doesn't need every type to be satisfied, you can have a set with just boots, or leggings etc. - the vanilla turtle shell helmet is a good example of an armor set with missing slots.
 
+### Durability {#durability}
+
+Unlike `ToolMaterial`, `ArmorMaterial` doesn't store any information about the durability of items.
+For this reason the durability needs to be added to the armor items' `Item.Settings` when registering them.
+
+This is achieved using the `maxDamage` method in the `Item.Settings` class.
+The different armor slots have different base durabilities which are commonly multiplied by a shared armor material multiplier to set the durability but hard-coded values can also be used.
+
+For the Guidite armor we'll be using a shared armor multiplier stored alongside the armor material:
+
+@[code transcludeWith=:::3](@/reference/latest/src/main/java/com/example/docs/item/armor/ModArmorMaterials.java)
+
+We can then create the armor items using the durability constant:
+
 @[code transcludeWith=:::6](@/reference/latest/src/main/java/com/example/docs/item/ModItems.java)
 
 You will also need to **add the items to an item group** if you want them to be accessible from the creative inventory.

--- a/reference/latest/src/main/java/com/example/docs/item/ModItems.java
+++ b/reference/latest/src/main/java/com/example/docs/item/ModItems.java
@@ -32,10 +32,10 @@ public class ModItems {
 	// :::1
 
 	// :::6
-	public static final Item GUIDITE_HELMET = register(new ArmorItem(ModArmorMaterials.GUIDITE, ArmorItem.Type.HELMET, new Item.Settings()), "guidite_helmet");
-	public static final Item GUIDITE_CHESTPLATE = register(new ArmorItem(ModArmorMaterials.GUIDITE, ArmorItem.Type.CHESTPLATE, new Item.Settings()), "guidite_chestplate");
-	public static final Item GUIDITE_LEGGINGS = register(new ArmorItem(ModArmorMaterials.GUIDITE, ArmorItem.Type.LEGGINGS, new Item.Settings()), "guidite_leggings");
-	public static final Item GUIDITE_BOOTS = register(new ArmorItem(ModArmorMaterials.GUIDITE, ArmorItem.Type.BOOTS, new Item.Settings()), "guidite_boots");
+	public static final Item GUIDITE_HELMET = register(new ArmorItem(ModArmorMaterials.GUIDITE, ArmorItem.Type.HELMET, new Item.Settings().maxDamage(ArmorItem.Type.HELMET.getMaxDamage(ModArmorMaterials.GUIDITE_DURABILITY_MULTIPLIER))), "guidite_helmet");
+	public static final Item GUIDITE_CHESTPLATE = register(new ArmorItem(ModArmorMaterials.GUIDITE, ArmorItem.Type.CHESTPLATE, new Item.Settings().maxDamage(ArmorItem.Type.CHESTPLATE.getMaxDamage(ModArmorMaterials.GUIDITE_DURABILITY_MULTIPLIER))), "guidite_chestplate");
+	public static final Item GUIDITE_LEGGINGS = register(new ArmorItem(ModArmorMaterials.GUIDITE, ArmorItem.Type.LEGGINGS, new Item.Settings().maxDamage(ArmorItem.Type.LEGGINGS.getMaxDamage(ModArmorMaterials.GUIDITE_DURABILITY_MULTIPLIER))), "guidite_leggings");
+	public static final Item GUIDITE_BOOTS = register(new ArmorItem(ModArmorMaterials.GUIDITE, ArmorItem.Type.BOOTS, new Item.Settings().maxDamage(ArmorItem.Type.BOOTS.getMaxDamage(ModArmorMaterials.GUIDITE_DURABILITY_MULTIPLIER))), "guidite_boots");
 	// :::6
 	public static final Item LIGHTNING_STICK = register(new LightningStick(new Item.Settings()), "lightning_stick");
 	// :::7

--- a/reference/latest/src/main/java/com/example/docs/item/armor/ModArmorMaterials.java
+++ b/reference/latest/src/main/java/com/example/docs/item/armor/ModArmorMaterials.java
@@ -18,6 +18,11 @@ import com.example.docs.FabricDocsReference;
 import com.example.docs.item.ModItems;
 
 public class ModArmorMaterials {
+
+	// :::3
+	public static final int GUIDITE_DURABILITY_MULTIPLIER = 15;
+	// :::3
+
 	// :::2
 	public static final RegistryEntry<ArmorMaterial> GUIDITE = registerMaterial("guidite",
 			// Defense (protection) point values for each armor piece.

--- a/reference/latest/src/main/java/com/example/docs/item/armor/ModArmorMaterials.java
+++ b/reference/latest/src/main/java/com/example/docs/item/armor/ModArmorMaterials.java
@@ -18,11 +18,9 @@ import com.example.docs.FabricDocsReference;
 import com.example.docs.item.ModItems;
 
 public class ModArmorMaterials {
-
 	// :::3
 	public static final int GUIDITE_DURABILITY_MULTIPLIER = 15;
 	// :::3
-
 	// :::2
 	public static final RegistryEntry<ArmorMaterial> GUIDITE = registerMaterial("guidite",
 			// Defense (protection) point values for each armor piece.


### PR DESCRIPTION
Minecraft changed the way durability works with armor items and armor materials. I added a small explainer to durability in the docs.

Closes #151 

Note regarding [the implementation](https://github.com/FabricMC/fabric-docs/issues/151#issuecomment-2246285823): I used a durability multiplier and referenced the `ArmorItem.Type`'s base durabilities mimicking the vanilla armor registries.