### PR TITLE
Fix Crashes with Potions

### DIFF
--- a/reference/latest/src/main/java/com/example/docs/potion/FabricDocsReferencePotions.java
+++ b/reference/latest/src/main/java/com/example/docs/potion/FabricDocsReferencePotions.java
@@ -6,7 +6,6 @@ import net.minecraft.potion.Potion;
 import net.minecraft.potion.Potions;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
-import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.util.Identifier;
 
 import net.fabricmc.api.ModInitializer;
@@ -22,7 +21,7 @@ public class FabricDocsReferencePotions implements ModInitializer {
 					Identifier.of("fabric-docs-reference", "tater"),
 					new Potion(
 							new StatusEffectInstance(
-									RegistryEntry.of(FabricDocsReferenceEffects.TATER_EFFECT),
+									Registries.STATUS_EFFECT.getEntry(FabricDocsReferenceEffects.TATER_EFFECT),
 									3600,
 									0)));
 
@@ -35,7 +34,7 @@ public class FabricDocsReferencePotions implements ModInitializer {
 					// Ingredient
 					Items.POTATO,
 					// Output potion.
-					RegistryEntry.of(TATER_POTION)
+					Registries.POTION.getEntry(TATER_POTION)
 			);
 		});
 	}


### PR DESCRIPTION
Based on the discussion: [The Fabric Project > #docs](https://discord.com/channels/507304429255393322/1208846408552030238/1266026056599732296). The crashes seem to be solved.

Edit: No doc changes required, as this is just one way of obtaining a `RegistryEntry<StatusEffect>`.

Credits to @JaaiDead for pointing out the fix.