### PR TITLE
Fix editor config import layout to match spotless

### DIFF
--- a/reference/.editorconfig
+++ b/reference/.editorconfig
@@ -1,6 +1,6 @@
 [*.{gradle,java}]
 indent_style = tab
 ij_continuation_indent_size = 8
-ij_java_imports_layout = $*,|,java.**,|,javax.**,|,*,|,net.fabricmc.**,com.example.**
+ij_java_imports_layout = $*,|,java.**,|,javax.**,|,*,|,net.minecraft.**,|,net.fabricmc.**,|,com.example.**
 ij_java_class_count_to_use_import_on_demand = 999
 trim_trailing_whitespace = true


### PR DESCRIPTION
Fix editor config currently not matching spotless.

I've tested this in every java file in the reference mod and it works without any problems.