### PR TITLE
Fix 'important' section on Updating Fabric

### DIFF
--- a/players/updating-fabric.md
+++ b/players/updating-fabric.md
@@ -23,9 +23,9 @@ Newer mods may require a newer version of Fabric Loader to work, so it's importa
 
 To update Fabric, simply ensure the game version and Loader version is correct then click `Install`.
 
-::: important
+> [!IMPORTANT]
 Make sure to uncheck 'Create Profile' when running the installer, otherwise it will create a new profile, which in this case we don't need.
-:::
+
 
 ## 3. Open the Profile in the Minecraft Launcher {#3-open-the-profile-in-the-minecraft-launcher}
 

--- a/players/updating-fabric.md
+++ b/players/updating-fabric.md
@@ -23,9 +23,9 @@ Newer mods may require a newer version of Fabric Loader to work, so it's importa
 
 To update Fabric, simply ensure the game version and Loader version is correct then click `Install`.
 
-> [!IMPORTANT]
+::: warning IMPORTANT
 Make sure to uncheck 'Create Profile' when running the installer, otherwise it will create a new profile, which in this case we don't need.
-
+:::
 
 ## 3. Open the Profile in the Minecraft Launcher {#3-open-the-profile-in-the-minecraft-launcher}
 


### PR DESCRIPTION
The IMPORTANT section of the `Updating Fabric` page wasn't working before, so I fixed it by using the "GitHub-flavored Alerts".

Before:
![image](https://github.com/user-attachments/assets/6ce3bc75-c165-40a6-a98c-1be7d2a58d10)

After:
![image](https://github.com/user-attachments/assets/5356a808-b58d-4cf2-b508-b8517c67895c)


