### PR TITLE
Fix for changes made in 1.21.3 (and above) that change how blocks & items are registered CLOSED BECAUSE: (forgot some things mb)

### DIFF
--- a/reference/latest/src/main/java/com/example/docs/block/ModBlocks.java
+++ b/reference/latest/src/main/java/com/example/docs/block/ModBlocks.java
@@ -59,6 +59,35 @@ public class ModBlocks {
 		return Registry.register(Registries.BLOCK, id, block);
 	}
 
+	// [1.21.3 and above]
+	private static Block reigster(Function<AbstractBlock.Settings, Block> blockProvider, String id, boolean shouldRegisterItem) {
+		
+		// makes identifier for the registryKeys (so you don't repeat yourself)
+		Identifier identifier = Identifier.of(FabricDocsReference.MOD_ID, id);
+
+		// creates registryKey for block. (needed)
+		RegistryKey blockKey = RegistryKey.of(Registries.BLOCK, identifier);
+
+		// creates the block & adds the block key to the settings. 
+		Block block = blockProvider.apply(AbstractBlock.Settings.create().registryKey(blockKey));
+
+		// registers block.
+		Block registeredBlock = Registry.register(Registries.ITEM, blockKey, block);
+		
+		if (shouldRegisterItem) {
+			
+			// creates item registry key. (needed)
+			RegistryKey itemKey = RegistryKey.of(Registries.ITEM, identifier);
+			
+			// registers blockItem
+			Registry.register(Registries.ITEM, itemKey, new BlockItem(registeredBlock, new Item.Settings().registryKey(itemKey)));
+		}
+		
+		// returns registered block.
+		return registeredBlock;
+	}
+
+	
 	// :::1
 	public static void initialize() {
 		// :::3

--- a/reference/latest/src/main/java/com/example/docs/block/ModBlocks.java
+++ b/reference/latest/src/main/java/com/example/docs/block/ModBlocks.java
@@ -87,6 +87,14 @@ public class ModBlocks {
 		return registeredBlock;
 	}
 
+	// [1.21.3 and above]
+	public static final Block EXAMPLE_BLOCK_FOR_21_3 = register(settings -> {
+
+		// change the settings however you want.
+		
+		return new Block(settings);
+	});
+	
 	
 	// :::1
 	public static void initialize() {

--- a/reference/latest/src/main/java/com/example/docs/block/ModBlocks.java
+++ b/reference/latest/src/main/java/com/example/docs/block/ModBlocks.java
@@ -87,13 +87,16 @@ public class ModBlocks {
 		return registeredBlock;
 	}
 
-	// [1.21.3 and above]
-	public static final Block EXAMPLE_BLOCK_FOR_21_3 = register(settings -> {
+	// [1.21.3 and above] for adding settings
+	public static final Block EXAMPLE_BLOCK_FOR_21_3_A = register(settings -> {
 
 		// change the settings however you want.
 		
 		return new Block(settings);
-	});
+	}, "example_block_for_21_3_a");
+
+	// [1.21.3 and above] for no settings
+	public static final Block EXAMPLE_BLOCK_FOR_21_3_B = register(Block::new, "example_block_for_21_3_b");
 	
 	
 	// :::1

--- a/reference/latest/src/main/java/com/example/docs/item/ModItems.java
+++ b/reference/latest/src/main/java/com/example/docs/item/ModItems.java
@@ -78,6 +78,7 @@ public class ModItems {
 	// :::2
 
 	// :::1
+	// [1.21.2 and below]
 	public static Item register(Item item, String id) {
 		// Create the identifier for the item.
 		Identifier itemID = Identifier.of(FabricDocsReference.MOD_ID, id);
@@ -89,6 +90,30 @@ public class ModItems {
 		return registeredItem;
 	}
 
+	// [1.21.3 and ablove]
+	public static Item register(Function<Item.Settings, Item> itemProvider, String id) {
+		
+		// creates a registryKey ... I dunno how to explain this one tbh. Someone will fill this in.
+		RegistryKey key = RegistryKey.of(Registries.ITEM, Identifier.of(FabricDocsReference.MOD_ID, id));
+
+		// Returns registered item. & adds the registrykey from before to the settings :D.
+		return Registry.register(Registries.ITEM, key, itemProvider.apply(new Item.Settings().registryKey(key)));
+	}
+	
+	// [1.21.3 and ablove] for when you want to add item settings.
+	public static final Item EXAMPLE_ITEM_FOR_NEW_UPDATES_A = register(settings -> {
+		
+		// do whatever u want with the settings
+		settings.maxCount(1);
+		
+		// returns item.
+		return new Item(settings);
+		
+	}, "example_item_for_new_updates")
+	
+	// [1.21.3 and ablove] for no item settings.
+	public static final Item EXAMPLE_ITEM_FOR_NEW_UPDATES_B = register(Item::new, "example_item_for_new_updates_1")
+	
 	// :::1
 
 	// :::3


### PR DESCRIPTION
adds onto ModItems.java file to add the new way to register items clearly commented out :).
add onto ModBlocks.java file to add the new way to register blocks. & Again clearly commented :).

also adds 2 new items & blocks to demonstrate the 2 ways you can register (1 for settings & another for no settings)