### PR TITLE
Update to 1.21.4: "Creating Your First Item"

### DIFF
--- a/develop/items/first-item.md
+++ b/develop/items/first-item.md
@@ -98,7 +98,14 @@ You're going to create a simple `item/generated` model, which takes in an input 
 
 Create the model JSON in the `assets/<mod id here>/models/item` folder, with the same name as the item; `suspicious_substance.json`
 
-@[code](@/reference/latest/src/main/resources/assets/fabric-docs-reference/models/item/suspicious_substance.json)
+But we're still missing a thing: the item still doesn't load?
+
+### Adding an Item Description {#adding-an-item-description}
+
+Since 1.21.4, Minecraft won't try to guess your item model's location anymore, and so, we need to provide an item description.
+
+Create the item description JSON in the `assets/<mod id here>/items`, with the same name as the item; `suspicious_substance.json`.
+@[code](@/reference/latest/src/main/resources/assets/fabric-docs-reference/items/suspicious_substance.json)
 
 ### Breaking Down the Model JSON {#breaking-down-the-model-json}
 
@@ -108,6 +115,11 @@ Create the model JSON in the `assets/<mod id here>/models/item` folder, with the
 Most items will use the `item/generated` model as their parent, as it's a simple model that just displays the texture.
 
 There are alternatives, such as `item/handheld` which is used for items that are held in the player's hand, such as tools.
+
+### Breaking Down the Item Description JSON {#breaking-down-the-item-description-json}
+- `model`: This is the property that contains the reference to our model.
+  - `type`: This is the type of our model. For most items, this should be `minecraft:model`
+  - `model`: This is the model's identifier. It should have this form: `<mod id here>:item/<item name here>`
 
 Your item should now look like this in-game:
 

--- a/develop/items/first-item.md
+++ b/develop/items/first-item.md
@@ -98,6 +98,8 @@ You're going to create a simple `item/generated` model, which takes in an input 
 
 Create the model JSON in the `assets/<mod id here>/models/item` folder, with the same name as the item; `suspicious_substance.json`
 
+@[code](@/reference/latest/src/main/resources/assets/fabric-docs-reference/models/item/suspicious_substance.json)
+
 But we're still missing a thing: the item still doesn't load?
 
 ### Adding an Item Description {#adding-an-item-description}

--- a/reference/1.20.4/src/main/resources/assets/fabric-docs-reference/items/suspicious_substance.json
+++ b/reference/1.20.4/src/main/resources/assets/fabric-docs-reference/items/suspicious_substance.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "minecraft:model",
+    "model": "fabric-docs-reference:item/suspicious_substance"
+  }
+}

--- a/reference/1.20.4/src/main/resources/assets/fabric-docs-reference/items/suspicious_substance.json
+++ b/reference/1.20.4/src/main/resources/assets/fabric-docs-reference/items/suspicious_substance.json
@@ -1,6 +1,6 @@
 {
   "model": {
     "type": "minecraft:model",
-    "model": "fabric-docs-reference:item/suspicious_substance"
+    "model": "mod_id:item/suspicious_substance"
   }
 }


### PR DESCRIPTION
Since 1.21.4, Minecraft doesn't try to guess your model's location anymore, and so, we should now add an item description JSON in `assets/modid/items`, so this pull request aims to point out that in the documentation.

I only added the description for the Suspicious Substance, and not for the other items of the reference mod.