### PR TITLE
Fix Mozilla's license URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ If you wish to contribute translations, you can do so via the [Crowdin project](
 
 - Thank you to all the [contributors to the repo](https://github.com/FabricMC/fabric-docs/graphs/contributors), who are helping create guides for the documentation!
 - A huge thank you to users who are translating guides to other languages via the [Crowdin project](https://crowdin.com/project/fabricmc)
-- `CountryFlagsPolyfill.woff2` is adapted from "Twemoji Mozilla" by Mozilla & X (formerly Twitter) contributors, licensed under CC-BY-4.0. Modifications include storing only the flag emoticons ("Emojis"). Original license details are available at [Twemoji Mozilla](https://github.com/mozilla/twemoji-colr/blob/master/LICENSE#license-for-the-visual-design)
+- `CountryFlagsPolyfill.woff2` is adapted from "Twemoji Mozilla" by Mozilla & X (formerly Twitter) contributors, licensed under CC-BY-4.0. Modifications include storing only the flag emoticons ("Emojis"). Original license details are available at [Twemoji Mozilla](https://github.com/mozilla/twemoji-colr/blob/master/LICENSE.md#license-for-the-visual-design)


### PR DESCRIPTION
Minor fix - the link to Mozilla's license file has either changed or was typoed, as it is missing the file extension.