### PR TITLE
Remove BlockWithEntity getRenderType overrides

### DIFF
--- a/develop/blocks/block-entities.md
+++ b/develop/blocks/block-entities.md
@@ -32,7 +32,7 @@ Next, to actually use the block entity, we need a block that implements `BlockEn
 ::: tip
 There's two ways to approach this:
 
-- create a block that extends `BlockWithEntity` and implement the `createBlockEntity` method (_and_ the `getRenderType` method, since `BlockWithEntity` makes it invisible by default)
+- create a block that extends `BlockWithEntity` and implement the `createBlockEntity` method
 - create a block that implements `BlockEntityProvider` by itself and override the `createBlockEntity` method
 
 We'll use the first approach in this example, since `BlockWithEntity` also provides some nice utilities.

--- a/reference/latest/src/main/java/com/example/docs/block/custom/CounterBlock.java
+++ b/reference/latest/src/main/java/com/example/docs/block/custom/CounterBlock.java
@@ -3,7 +3,6 @@ package com.example.docs.block.custom;
 import com.mojang.serialization.MapCodec;
 import org.jetbrains.annotations.Nullable;
 
-import net.minecraft.block.BlockRenderType;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.BlockWithEntity;
 import net.minecraft.block.entity.BlockEntity;
@@ -28,11 +27,6 @@ public class CounterBlock extends BlockWithEntity {
 	@Override
 	protected MapCodec<? extends BlockWithEntity> getCodec() {
 		return createCodec(CounterBlock::new);
-	}
-
-	@Override
-	protected BlockRenderType getRenderType(BlockState state) {
-		return BlockRenderType.MODEL;
 	}
 
 	@Nullable

--- a/reference/latest/src/main/java/com/example/docs/block/custom/EngineBlock.java
+++ b/reference/latest/src/main/java/com/example/docs/block/custom/EngineBlock.java
@@ -3,7 +3,6 @@ package com.example.docs.block.custom;
 import com.mojang.serialization.MapCodec;
 import org.jetbrains.annotations.Nullable;
 
-import net.minecraft.block.BlockRenderType;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.BlockWithEntity;
 import net.minecraft.block.entity.BlockEntity;
@@ -72,11 +71,6 @@ public class EngineBlock extends BlockWithEntity {
 		}
 
 		return ActionResult.PASS;
-	}
-
-	@Override
-	protected BlockRenderType getRenderType(BlockState state) {
-		return BlockRenderType.MODEL;
 	}
 
 	private static void playSound(World world, SoundEvent soundEvent, BlockPos pos) {


### PR DESCRIPTION
These overrides have been unnecessary since 24w46a (1.21.4). They were there because previously, Mojang had an override in `BlockWithEntity` for `getRenderType` to return `BlockRenderType.INVISIBLE`, and these were to override it back to `BlockRenderType.MODEL`. Mojang has now removed this override, making these ones in the docs unnecessary.