### PR TITLE
Cleanup register methods

### DIFF
--- a/develop/blocks/first-block.md
+++ b/develop/blocks/first-block.md
@@ -39,14 +39,14 @@ public class ModBlocks {
 
 ## Creating And Registering Your Block {#creating-and-registering-your-block}
 
-Similarly to items, blocks take a `Blocks.Settings` class in their constructor, which specifies properties about the block, such as its sound effects and mining level.
+Similarly to items, blocks take a `AbstractBlock.Settings` class in their constructor, which specifies properties about the block, such as its sound effects and mining level.
 
 We will not cover all the options here: you can view the class yourself to see the various options, which should be self-explanatory.
 
 For example purposes, we will be creating a simple block that has the properties of dirt, but is a different material.
 
-- We need a `RegistryKey<Block>` which is used as a unique identifier for our block, this is passed into `Registry.register` in the previous utility method.
-- The `RegistryKey<Block>` is also required by the `AbstractBlock.Settings` builder.
+- We create our block settings in a similar way to how we created item settings in the item tutorial.
+- We tell the `register` method to create a `Block` instance from the block settings by calling the `Block` constructor.
 
 ::: tip
 You can also use `AbstractBlock.Settings.copy(AbstractBlock block)` to copy the settings of an existing block, in this case, we could have used `Blocks.DIRT` to copy the settings of dirt, but for example purposes we'll use the builder.

--- a/develop/blocks/first-block.md
+++ b/develop/blocks/first-block.md
@@ -5,6 +5,7 @@ authors:
   - IMB11
   - xEobardThawne
   - its-miroma
+  - Earthcomputer
 ---
 
 Blocks are the building blocks of Minecraft (no pun intended) - just like everything else in Minecraft, they're stored in registries.

--- a/develop/items/first-item.md
+++ b/develop/items/first-item.md
@@ -30,10 +30,10 @@ Notice the usage of a [`Function`](https://docs.oracle.com/en/java/javase/21/doc
 
 You can now register an item using the method now.
 
-The register method takes in an instance of the `Items.Settings` class as a parameter. This class allows you to configure the item's properties through various builder methods.
+The register method takes in an instance of the `Item.Settings` class as a parameter. This class allows you to configure the item's properties through various builder methods.
 
 ::: tip
-If you want to change your item's stack size, you can use the `maxCount` method in the `Items.Settings` class.
+If you want to change your item's stack size, you can use the `maxCount` method in the `Item.Settings` class.
 
 This will not work if you've marked the item as damageable, as the stack size is always 1 for damageable items to prevent duplication exploits.
 :::

--- a/develop/items/first-item.md
+++ b/develop/items/first-item.md
@@ -5,6 +5,7 @@ authors:
   - IMB11
   - dicedpixels
   - RaphProductions
+  - Earthcomputer
 ---
 
 This page will introduce you into some key concepts relating to items, and how you can register, texture, model and name them.

--- a/develop/items/first-item.md
+++ b/develop/items/first-item.md
@@ -23,7 +23,7 @@ Mojang does this with their items as well! Check out the `Items` class for inspi
 
 @[code transcludeWith=:::1](@/reference/latest/src/main/java/com/example/docs/item/ModItems.java)
 
-This method uses the [`Function`](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/function/Function.html) interface for the factory, which will allow us to specify how we want our item to be created from the item settings using a [lambda expression](https://www.w3schools.com/java/java_lambda.asp) or a method reference such as `Item::new`, like we do below.
+Notice the usage of a [`Function`](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/function/Function.html) interface for the factory, which will later allow us to specify how we want our item to be created from the item settings using `Item::new`.
 
 ## Registering an Item {#registering-an-item}
 

--- a/develop/items/first-item.md
+++ b/develop/items/first-item.md
@@ -13,7 +13,7 @@ If you aren't aware, everything in Minecraft is stored in registries, and items 
 
 ## Preparing Your Items Class {#preparing-your-items-class}
 
-To simplify the registering of items, you can create a method that accepts an instance of an item and a string identifier.
+To simplify the registering of items, you can create a method that accepts a string identifier, some item settings and a factory to create the `Item` instance.
 
 This method will create an item with the provided identifier and register it with the game's item registry.
 
@@ -23,19 +23,23 @@ Mojang does this with their items as well! Check out the `Items` class for inspi
 
 @[code transcludeWith=:::1](@/reference/latest/src/main/java/com/example/docs/item/ModItems.java)
 
+This method uses the [`Function`](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/function/Function.html) interface for the factory, which will allow us to specify how we want our item to be created from the item settings using a [lambda expression](https://www.w3schools.com/java/java_lambda.asp) or a method reference such as `Item::new`, like we do below.
+
 ## Registering an Item {#registering-an-item}
 
 You can now register an item using the method now.
 
-The item constructor takes in an instance of the `Items.Settings` class as a parameter. This class allows you to configure the item's properties through various builder methods.
+The register method takes in an instance of the `Items.Settings` class as a parameter. This class allows you to configure the item's properties through various builder methods.
 
 ::: tip
-If you want to change your item's stack size, you can use the `maxCount` method in the `Items.Settings`/`FabricItemSettings` class.
+If you want to change your item's stack size, you can use the `maxCount` method in the `Items.Settings` class.
 
 This will not work if you've marked the item as damageable, as the stack size is always 1 for damageable items to prevent duplication exploits.
 :::
 
 @[code transcludeWith=:::2](@/reference/latest/src/main/java/com/example/docs/item/ModItems.java)
+
+`Item::new` tells the register function to create an `Item` instance from an `Item.Settings` by calling the `Item` constructor (`new Item(...)`), which takes an `Item.Settings` as a parameter.
 
 However, if you now try to run the modified client, you can see that our item doesn't exist in-game yet! This is because you didn't statically initialize the class.
 

--- a/reference/latest/src/main/generated/data/fabric-docs-reference/advancement/break_block_with_tool.json
+++ b/reference/latest/src/main/generated/data/fabric-docs-reference/advancement/break_block_with_tool.json
@@ -2,7 +2,7 @@
   "parent": "fabric-docs-reference:get_dirt",
   "criteria": {
     "break_block_with_tool": {
-      "trigger": "minecraft:fabric-docs-reference/use_tool"
+      "trigger": "fabric-docs-reference:use_tool"
     }
   },
   "display": {

--- a/reference/latest/src/main/generated/data/fabric-docs-reference/advancement/break_block_with_tool_five_times.json
+++ b/reference/latest/src/main/generated/data/fabric-docs-reference/advancement/break_block_with_tool_five_times.json
@@ -5,7 +5,7 @@
       "conditions": {
         "requiredTimes": 5
       },
-      "trigger": "minecraft:fabric-docs-reference/parameterized_use_tool"
+      "trigger": "fabric-docs-reference:parameterized_use_tool"
     }
   },
   "display": {

--- a/reference/latest/src/main/java/com/example/docs/advancement/ModCriteria.java
+++ b/reference/latest/src/main/java/com/example/docs/advancement/ModCriteria.java
@@ -8,10 +8,10 @@ import com.example.docs.FabricDocsReference;
 public class ModCriteria {
 	// :::datagen-advancements:mod-criteria-init
 	// :::datagen-advancements:mod-criteria
-	public static final UseToolCriterion USE_TOOL = Criteria.register(FabricDocsReference.MOD_ID + "/use_tool", new UseToolCriterion());
+	public static final UseToolCriterion USE_TOOL = Criteria.register(FabricDocsReference.MOD_ID + ":use_tool", new UseToolCriterion());
 	// :::datagen-advancements:mod-criteria
 	// :::datagen-advancements:new-mod-criteria
-	public static final ParameterizedUseToolCriterion PARAMETERIZED_USE_TOOL = Criteria.register(FabricDocsReference.MOD_ID + "/parameterized_use_tool", new ParameterizedUseToolCriterion());
+	public static final ParameterizedUseToolCriterion PARAMETERIZED_USE_TOOL = Criteria.register(FabricDocsReference.MOD_ID + ":parameterized_use_tool", new ParameterizedUseToolCriterion());
 
 	// :::datagen-advancements:mod-criteria
 	// :::datagen-advancements:mod-criteria-init

--- a/reference/latest/src/main/java/com/example/docs/block/ModBlocks.java
+++ b/reference/latest/src/main/java/com/example/docs/block/ModBlocks.java
@@ -2,8 +2,6 @@ package com.example.docs.block;
 
 import java.util.function.Function;
 
-import org.jetbrains.annotations.NotNull;
-
 import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockSetType;
@@ -37,45 +35,31 @@ public class ModBlocks {
 	// :::1
 
 	// :::2
-	public static final RegistryKey<Block> CONDENSED_DIRT_KEY = RegistryKey.of(
-			RegistryKeys.BLOCK,
-			Identifier.of(FabricDocsReference.MOD_ID, "condensed_dirt")
-	);
-
 	public static final Block CONDENSED_DIRT = register(
-			new Block(AbstractBlock.Settings.create().registryKey(CONDENSED_DIRT_KEY).sounds(BlockSoundGroup.GRASS)),
-			CONDENSED_DIRT_KEY,
+			"condensed_dirt",
+			Block::new,
+			AbstractBlock.Settings.create().sounds(BlockSoundGroup.GRASS),
 			true
 	);
 
 	// :::2
 	// :::3
-	public static final RegistryKey<Block> CONDENSED_OAK_LOG_KEY = RegistryKey.of(
-			RegistryKeys.BLOCK,
-			Identifier.of(FabricDocsReference.MOD_ID, "condensed_oak_log")
-	);
-
 	public static final Block CONDENSED_OAK_LOG = register(
-			new PillarBlock(
-					AbstractBlock.Settings.create()
-							.registryKey(CONDENSED_OAK_LOG_KEY)
-							.sounds(BlockSoundGroup.WOOD)
-			), CONDENSED_OAK_LOG_KEY, true
+			"condensed_oak_log",
+			PillarBlock::new,
+			AbstractBlock.Settings.create().sounds(BlockSoundGroup.WOOD),
+			true
 	);
 
 	// :::3
 	// :::4
-	public static final RegistryKey<Block> PRISMARINE_LAMP_KEY = RegistryKey.of(
-			RegistryKeys.BLOCK,
-			Identifier.of(FabricDocsReference.MOD_ID, "prismarine_lamp")
-	);
 	public static final Block PRISMARINE_LAMP = register(
-			new PrismarineLampBlock(
-					AbstractBlock.Settings.create()
-							.registryKey(PRISMARINE_LAMP_KEY)
-							.sounds(BlockSoundGroup.LANTERN)
-							.luminance(PrismarineLampBlock::getLuminance)
-			), PRISMARINE_LAMP_KEY, true
+			"prismarine_lamp",
+			PrismarineLampBlock::new,
+			AbstractBlock.Settings.create()
+					.sounds(BlockSoundGroup.LANTERN)
+					.luminance(PrismarineLampBlock::getLuminance),
+			true
 	);
 	// :::4
 	public static final RegistryKey<Block> ENGINE_BLOCK_KEY = RegistryKey.of(
@@ -83,48 +67,51 @@ public class ModBlocks {
 			Identifier.of(FabricDocsReference.MOD_ID, "engine")
 	);
 	public static final Block ENGINE_BLOCK = register(
-			new EngineBlock(AbstractBlock.Settings.create().registryKey(ENGINE_BLOCK_KEY)), ENGINE_BLOCK_KEY, true
+			"engine",
+			EngineBlock::new,
+			AbstractBlock.Settings.create().registryKey(ENGINE_BLOCK_KEY),
+			true
 	);
 
 	// :::5
-	public static final RegistryKey<Block> COUNTER_BLOCK_KEY = RegistryKey.of(
-			RegistryKeys.BLOCK,
-			Identifier.of(FabricDocsReference.MOD_ID, "counter_block")
-	);
 	public static final Block COUNTER_BLOCK = register(
-			new CounterBlock(AbstractBlock.Settings.create().registryKey(COUNTER_BLOCK_KEY)), COUNTER_BLOCK_KEY, true
+			"counter_block",
+			CounterBlock::new,
+			AbstractBlock.Settings.create(),
+			true
 	);
 	// :::5
 
-	public static final Block STEEL_BLOCK = registerBlock(
-			"steel_block", PillarBlock::new, AbstractBlock.Settings.create()
+	public static final Block STEEL_BLOCK = register(
+			"steel_block", PillarBlock::new, AbstractBlock.Settings.create(), true
 	);
-	public static final Block PIPE_BLOCK = registerBlock(
-			"pipe_block", Block::new, AbstractBlock.Settings.create()
-	);
-
-	public static final Block RUBY_BLOCK = registerBlock(
-			"ruby_block", Block::new, AbstractBlock.Settings.create()
-	);
-	public static final Block RUBY_STAIRS = registerBlock(
-			"ruby_stairs", settings -> new StairsBlock(RUBY_BLOCK.getDefaultState(), settings), AbstractBlock.Settings.create()
-	);
-	public static final Block RUBY_SLAB = registerBlock(
-			"ruby_slab", SlabBlock::new, AbstractBlock.Settings.create()
-	);
-	public static final Block RUBY_FENCE = registerBlock(
-			"ruby_fence", FenceBlock::new, AbstractBlock.Settings.create()
+	public static final Block PIPE_BLOCK = register(
+			"pipe_block", Block::new, AbstractBlock.Settings.create(), true
 	);
 
-	public static final Block RUBY_DOOR = registerBlock(
-			"ruby_door", settings -> new DoorBlock(BlockSetType.STONE, settings), AbstractBlock.Settings.create()
+	public static final Block RUBY_BLOCK = register(
+			"ruby_block", Block::new, AbstractBlock.Settings.create(), true
 	);
-	public static final Block RUBY_TRAPDOOR = registerBlock(
-			"ruby_trapdoor", settings -> new TrapdoorBlock(BlockSetType.STONE, settings), AbstractBlock.Settings.create()
+	public static final Block RUBY_STAIRS = register(
+			"ruby_stairs", settings -> new StairsBlock(RUBY_BLOCK.getDefaultState(), settings), AbstractBlock.Settings.create(), true
+	);
+	public static final Block RUBY_SLAB = register(
+			"ruby_slab", SlabBlock::new, AbstractBlock.Settings.create(), true
+	);
+	public static final Block RUBY_FENCE = register(
+			"ruby_fence", FenceBlock::new, AbstractBlock.Settings.create(), true
 	);
 
-	public static final Block VERTICAL_OAK_LOG_SLAB = registerBlock(
-			"vertical_oak_log_slab", VerticalSlabBlock::new, AbstractBlock.Settings.create());
+	public static final Block RUBY_DOOR = register(
+			"ruby_door", settings -> new DoorBlock(BlockSetType.STONE, settings), AbstractBlock.Settings.create(), true
+	);
+	public static final Block RUBY_TRAPDOOR = register(
+			"ruby_trapdoor", settings -> new TrapdoorBlock(BlockSetType.STONE, settings), AbstractBlock.Settings.create(), true
+	);
+
+	public static final Block VERTICAL_OAK_LOG_SLAB = register(
+			"vertical_oak_log_slab", VerticalSlabBlock::new, AbstractBlock.Settings.create(), true
+	);
 
 	// :::datagen-model:family-declaration
 	public static final BlockFamily RUBY_FAMILY =
@@ -136,13 +123,18 @@ public class ModBlocks {
 	// :::datagen-model:family-declaration
 
 	// :::1
-	public static Block register(Block block, RegistryKey<Block> blockKey, boolean shouldRegisterItem) {
+	private static Block register(String name, Function<AbstractBlock.Settings, Block> blockFactory, AbstractBlock.Settings settings, boolean shouldRegisterItem) {
+		// Create a registry key for the block
+		RegistryKey<Block> blockKey = keyOfBlock(name);
+		// Create the block instance
+		Block block = blockFactory.apply(settings.registryKey(blockKey));
+
 		// Sometimes, you may not want to register an item for the block.
-		// Eg: if it's a technical block like `minecraft:air` or `minecraft:end_gateway`
+		// Eg: if it's a technical block like `minecraft:moving_piston` or `minecraft:end_gateway`
 		if (shouldRegisterItem) {
 			// Items need to be registered with a different type of registry key, but the ID
 			// can be the same.
-			RegistryKey<Item> itemKey = RegistryKey.of(RegistryKeys.ITEM, blockKey.getValue());
+			RegistryKey<Item> itemKey = keyOfItem(name);
 
 			BlockItem blockItem = new BlockItem(block, new Item.Settings().registryKey(itemKey));
 			Registry.register(Registries.ITEM, itemKey, blockItem);
@@ -151,27 +143,15 @@ public class ModBlocks {
 		return Registry.register(Registries.BLOCK, blockKey, block);
 	}
 
-	// :::1
-
-	/** Helper methods for registering blocks (Fellteros). <br>
-	* Block would look like this:
-	 * <blockquote><pre>
-	 *     public static final Block TEST = registerBlock("test", Block::new, AbstractBlock.Settings.create());
-	 * </pre></blockquote>
-	 * */
-	private static Block registerBlock(String name, @NotNull Function<AbstractBlock.Settings, Block> function, AbstractBlock.@NotNull Settings settings) {
-		Block block = function.apply(settings.registryKey(keyOfBlock(name)));
-		Registry.register(Registries.ITEM, Identifier.of(FabricDocsReference.MOD_ID, name), new BlockItem(block, new Item.Settings().useBlockPrefixedTranslationKey().registryKey(keyOfItem(name))));
-		return Registry.register(Registries.BLOCK, keyOfBlock(name), block);
+	private static RegistryKey<Block> keyOfBlock(String name) {
+		return RegistryKey.of(RegistryKeys.BLOCK, Identifier.of(FabricDocsReference.MOD_ID, name));
 	}
 
 	private static RegistryKey<Item> keyOfItem(String name) {
 		return RegistryKey.of(RegistryKeys.ITEM, Identifier.of(FabricDocsReference.MOD_ID, name));
 	}
 
-	private static RegistryKey<Block> keyOfBlock(String name) {
-		return RegistryKey.of(RegistryKeys.BLOCK, Identifier.of(FabricDocsReference.MOD_ID, name));
-	}
+	// :::1
 
 	public static void initialize() {
 		setupItemGroups();

--- a/reference/latest/src/main/java/com/example/docs/block/entity/ModBlockEntities.java
+++ b/reference/latest/src/main/java/com/example/docs/block/entity/ModBlockEntities.java
@@ -22,9 +22,11 @@ public class ModBlockEntities {
 	public static final BlockEntityType<CounterBlockEntity> COUNTER_BLOCK_ENTITY =
 			register("counter", CounterBlockEntity::new, ModBlocks.COUNTER_BLOCK);
 
-	private static <T extends BlockEntity> BlockEntityType<T> register(String name,
-																	FabricBlockEntityTypeBuilder.Factory<? extends T> entityFactory,
-																	Block... blocks) {
+	private static <T extends BlockEntity> BlockEntityType<T> register(
+			String name,
+			FabricBlockEntityTypeBuilder.Factory<? extends T> entityFactory,
+			Block... blocks
+	) {
 		Identifier id = Identifier.of(FabricDocsReference.MOD_ID, name);
 		return Registry.register(Registries.BLOCK_ENTITY_TYPE, id, FabricBlockEntityTypeBuilder.<T>create(entityFactory, blocks).build());
 	}

--- a/reference/latest/src/main/java/com/example/docs/effect/FabricDocsReferenceEffects.java
+++ b/reference/latest/src/main/java/com/example/docs/effect/FabricDocsReferenceEffects.java
@@ -1,5 +1,7 @@
 package com.example.docs.effect;
 
+import com.example.docs.FabricDocsReference;
+
 import net.minecraft.entity.effect.StatusEffect;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
@@ -10,11 +12,8 @@ import net.fabricmc.api.ModInitializer;
 
 // :::1
 public class FabricDocsReferenceEffects implements ModInitializer {
-	public static final RegistryEntry<StatusEffect> TATER;
-
-	static {
-		TATER = Registry.registerReference(Registries.STATUS_EFFECT, Identifier.of("fabric-docs-reference", "tater"), new TaterEffect());
-	}
+	public static final RegistryEntry<StatusEffect> TATER =
+			Registry.registerReference(Registries.STATUS_EFFECT, Identifier.of(FabricDocsReference.MOD_ID, "tater"), new TaterEffect());
 
 	@Override
 	public void onInitialize() {

--- a/reference/latest/src/main/java/com/example/docs/effect/FabricDocsReferenceEffects.java
+++ b/reference/latest/src/main/java/com/example/docs/effect/FabricDocsReferenceEffects.java
@@ -1,7 +1,5 @@
 package com.example.docs.effect;
 
-import com.example.docs.FabricDocsReference;
-
 import net.minecraft.entity.effect.StatusEffect;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
@@ -9,6 +7,8 @@ import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.util.Identifier;
 
 import net.fabricmc.api.ModInitializer;
+
+import com.example.docs.FabricDocsReference;
 
 // :::1
 public class FabricDocsReferenceEffects implements ModInitializer {

--- a/reference/latest/src/main/java/com/example/docs/event/FabricDocsReferenceEvents.java
+++ b/reference/latest/src/main/java/com/example/docs/event/FabricDocsReferenceEvents.java
@@ -18,7 +18,7 @@ import net.fabricmc.fabric.api.loot.v3.LootTableEvents;
 
 // Class to contain all mod events.
 public class FabricDocsReferenceEvents implements ModInitializer {
-	private static final RegistryKey<LootTable> COAL_ORE_LOOT_TABLE_ID = Blocks.COAL_ORE.getLootTableKey().get();
+	private static final RegistryKey<LootTable> COAL_ORE_LOOT_TABLE_ID = Blocks.COAL_ORE.getLootTableKey().orElseThrow();
 
 	@Override
 	public void onInitialize() {

--- a/reference/latest/src/main/java/com/example/docs/item/ModItems.java
+++ b/reference/latest/src/main/java/com/example/docs/item/ModItems.java
@@ -33,6 +33,8 @@ import com.example.docs.item.armor.GuiditeArmorMaterial;
 import com.example.docs.item.custom.CounterItem;
 import com.example.docs.item.custom.LightningStick;
 
+import java.util.function.Function;
+
 // :::1
 public class ModItems {
 	// :::1
@@ -49,32 +51,44 @@ public class ModItems {
 	// :::guidite_tool_material
 
 	// :::6
-	public static final RegistryKey<Item> GUIDITE_HELMET_KEY = RegistryKey.of(RegistryKeys.ITEM, Identifier.of(FabricDocsReference.MOD_ID, "guidite_helmet"));
-	public static final Item GUIDITE_HELMET = register(new ArmorItem(GuiditeArmorMaterial.INSTANCE, EquipmentType.HELMET, new Item.Settings().registryKey(GUIDITE_HELMET_KEY).maxDamage(EquipmentType.HELMET.getMaxDamage(GuiditeArmorMaterial.BASE_DURABILITY))), GUIDITE_HELMET_KEY);
+	public static final Item GUIDITE_HELMET = register(
+			"guidite_helmet",
+			settings -> new ArmorItem(GuiditeArmorMaterial.INSTANCE, EquipmentType.HELMET, settings),
+			new Item.Settings().maxDamage(EquipmentType.HELMET.getMaxDamage(GuiditeArmorMaterial.BASE_DURABILITY))
+	);
+	public static final Item GUIDITE_CHESTPLATE = register("guidite_chestplate",
+			settings -> new ArmorItem(GuiditeArmorMaterial.INSTANCE, EquipmentType.CHESTPLATE, settings),
+			new Item.Settings().maxDamage(EquipmentType.CHESTPLATE.getMaxDamage(GuiditeArmorMaterial.BASE_DURABILITY))
+	);
 
-	public static final RegistryKey<Item> GUIDITE_CHESTPLATE_KEY = RegistryKey.of(RegistryKeys.ITEM, Identifier.of(FabricDocsReference.MOD_ID, "guidite_chestplate"));
-	public static final Item GUIDITE_CHESTPLATE = register(new ArmorItem(GuiditeArmorMaterial.INSTANCE, EquipmentType.CHESTPLATE, new Item.Settings().registryKey(GUIDITE_CHESTPLATE_KEY).maxDamage(EquipmentType.CHESTPLATE.getMaxDamage(GuiditeArmorMaterial.BASE_DURABILITY))), GUIDITE_CHESTPLATE_KEY);
+	public static final Item GUIDITE_LEGGINGS = register(
+			"guidite_leggings",
+			settings -> new ArmorItem(GuiditeArmorMaterial.INSTANCE, EquipmentType.LEGGINGS, settings),
+			new Item.Settings().maxDamage(EquipmentType.LEGGINGS.getMaxDamage(GuiditeArmorMaterial.BASE_DURABILITY))
+	);
 
-	public static final RegistryKey<Item> GUIDITE_LEGGINGS_KEY = RegistryKey.of(RegistryKeys.ITEM, Identifier.of(FabricDocsReference.MOD_ID, "guidite_leggings"));
-	public static final Item GUIDITE_LEGGINGS = register(new ArmorItem(GuiditeArmorMaterial.INSTANCE, EquipmentType.LEGGINGS, new Item.Settings().registryKey(GUIDITE_LEGGINGS_KEY).maxDamage(EquipmentType.LEGGINGS.getMaxDamage(GuiditeArmorMaterial.BASE_DURABILITY))), GUIDITE_LEGGINGS_KEY);
-
-	public static final RegistryKey<Item> GUIDITE_BOOTS_KEY = RegistryKey.of(RegistryKeys.ITEM, Identifier.of(FabricDocsReference.MOD_ID, "guidite_boots"));
-	public static final Item GUIDITE_BOOTS = register(new ArmorItem(GuiditeArmorMaterial.INSTANCE, EquipmentType.BOOTS, new Item.Settings().registryKey(GUIDITE_BOOTS_KEY).maxDamage(EquipmentType.BOOTS.getMaxDamage(GuiditeArmorMaterial.BASE_DURABILITY))), GUIDITE_BOOTS_KEY);
+	public static final Item GUIDITE_BOOTS = register(
+			"guidite_boots",
+			settings -> new ArmorItem(GuiditeArmorMaterial.INSTANCE, EquipmentType.BOOTS, settings),
+			new Item.Settings().maxDamage(EquipmentType.BOOTS.getMaxDamage(GuiditeArmorMaterial.BASE_DURABILITY))
+	);
 	// :::6
-	public static final RegistryKey<Item> LIGHTNING_STICK_KEY = RegistryKey.of(RegistryKeys.ITEM, Identifier.of(FabricDocsReference.MOD_ID, "lightning_stick"));
-	public static final Item LIGHTNING_STICK = register(new LightningStick(new Item.Settings().registryKey(LIGHTNING_STICK_KEY)), LIGHTNING_STICK_KEY);
+	public static final Item LIGHTNING_STICK = register("lightning_stick", LightningStick::new, new Item.Settings());
 	// :::7
-	public static final RegistryKey<Item> GUIDITE_SWORD_KEY = RegistryKey.of(RegistryKeys.ITEM, Identifier.of(FabricDocsReference.MOD_ID, "guidite_sword"));
-	public static final Item GUIDITE_SWORD = register(new SwordItem(GUIDITE_TOOL_MATERIAL, 1f, 1f, new Item.Settings().registryKey(GUIDITE_SWORD_KEY)), GUIDITE_SWORD_KEY);
+	public static final Item GUIDITE_SWORD = register(
+			"guidite_sword",
+			settings -> new SwordItem(GUIDITE_TOOL_MATERIAL, 1f, 1f, settings),
+			new Item.Settings()
+	);
 	// :::7
 	// :::_13
-	public static final RegistryKey<Item> COUNTER_KEY = RegistryKey.of(RegistryKeys.ITEM, Identifier.of(FabricDocsReference.MOD_ID, "counter"));
-	public static final Item COUNTER = register(new CounterItem(
-		new Item.Settings()
-				.registryKey(COUNTER_KEY)
-				// Initialize the click count component with a default value of 0
-				.component(ModComponents.CLICK_COUNT_COMPONENT, 0)
-	), COUNTER_KEY);
+	public static final Item COUNTER = register(
+			"counter",
+			CounterItem::new,
+			new Item.Settings()
+					// Initialize the click count component with a default value of 0
+					.component(ModComponents.CLICK_COUNT_COMPONENT, 0)
+	);
 	// :::_13
 	// :::9
 	public static final RegistryKey<ItemGroup> CUSTOM_ITEM_GROUP_KEY = RegistryKey.of(Registries.ITEM_GROUP.getKey(), Identifier.of(FabricDocsReference.MOD_ID, "item_group"));
@@ -94,27 +108,28 @@ public class ModItems {
 	// :::5
 
 	// :::poisonous_apple
-	public static final RegistryKey<Item> POISONOUS_APPLE_KEY = RegistryKey.of(RegistryKeys.ITEM, Identifier.of(FabricDocsReference.MOD_ID, "poisonous_apple"));
 	public static final Item POISONOUS_APPLE = register(
-			new Item(new Item.Settings().registryKey(POISONOUS_APPLE_KEY).food(POISON_FOOD_COMPONENT, POISON_FOOD_CONSUMABLE_COMPONENT)),
-			POISONOUS_APPLE_KEY
+			"poisonous_apple",
+			Item::new,
+			new Item.Settings().food(POISON_FOOD_COMPONENT, POISON_FOOD_CONSUMABLE_COMPONENT)
 	);
 	// :::poisonous_apple
 
 	// :::2
-	public static final RegistryKey<Item> SUSPICIOUS_SUBSTANCE_KEY = RegistryKey.of(RegistryKeys.ITEM, Identifier.of(FabricDocsReference.MOD_ID, "suspicious_substance"));
-	public static final Item SUSPICIOUS_SUBSTANCE = register(
-			new Item(new Item.Settings().registryKey(SUSPICIOUS_SUBSTANCE_KEY)),
-			SUSPICIOUS_SUBSTANCE_KEY
-	);
+	public static final Item SUSPICIOUS_SUBSTANCE = register("suspicious_substance", Item::new, new Item.Settings());
 	// :::2
 	// :::1
-	public static Item register(Item item, RegistryKey<Item> registryKey) {
-		// Register the item.
-		Item registeredItem = Registry.register(Registries.ITEM, registryKey.getValue(), item);
+	public static Item register(String name, Function<Item.Settings, Item> itemFactory, Item.Settings settings) {
+		// Create the item key.
+		RegistryKey<Item> itemKey = RegistryKey.of(RegistryKeys.ITEM, Identifier.of(FabricDocsReference.MOD_ID, name));
 
-		// Return the registered item!
-		return registeredItem;
+		// Create the item instance.
+		Item item = itemFactory.apply(settings.registryKey(itemKey));
+
+		// Register the item.
+		Registry.register(Registries.ITEM, itemKey, item);
+
+		return item;
 	}
 
 	// :::1

--- a/reference/latest/src/main/java/com/example/docs/item/ModItems.java
+++ b/reference/latest/src/main/java/com/example/docs/item/ModItems.java
@@ -1,5 +1,7 @@
 package com.example.docs.item;
 
+import java.util.function.Function;
+
 import net.minecraft.component.type.ConsumableComponent;
 import net.minecraft.component.type.ConsumableComponents;
 import net.minecraft.component.type.FoodComponent;
@@ -32,8 +34,6 @@ import com.example.docs.component.ModComponents;
 import com.example.docs.item.armor.GuiditeArmorMaterial;
 import com.example.docs.item.custom.CounterItem;
 import com.example.docs.item.custom.LightningStick;
-
-import java.util.function.Function;
 
 // :::1
 public class ModItems {

--- a/reference/latest/src/main/java/com/example/docs/potion/FabricDocsReferencePotions.java
+++ b/reference/latest/src/main/java/com/example/docs/potion/FabricDocsReferencePotions.java
@@ -1,7 +1,5 @@
 package com.example.docs.potion;
 
-import com.example.docs.FabricDocsReference;
-
 import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.item.Items;
 import net.minecraft.potion.Potion;
@@ -13,6 +11,7 @@ import net.minecraft.util.Identifier;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.registry.FabricBrewingRecipeRegistryBuilder;
 
+import com.example.docs.FabricDocsReference;
 import com.example.docs.effect.FabricDocsReferenceEffects;
 
 // :::1

--- a/reference/latest/src/main/java/com/example/docs/potion/FabricDocsReferencePotions.java
+++ b/reference/latest/src/main/java/com/example/docs/potion/FabricDocsReferencePotions.java
@@ -1,5 +1,7 @@
 package com.example.docs.potion;
 
+import com.example.docs.FabricDocsReference;
+
 import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.item.Items;
 import net.minecraft.potion.Potion;
@@ -18,7 +20,7 @@ public class FabricDocsReferencePotions implements ModInitializer {
 	public static final Potion TATER_POTION =
 			Registry.register(
 					Registries.POTION,
-					Identifier.of("fabric-docs-reference", "tater"),
+					Identifier.of(FabricDocsReference.MOD_ID, "tater"),
 					new Potion("tater",
 							new StatusEffectInstance(
 									FabricDocsReferenceEffects.TATER,


### PR DESCRIPTION
Uses block and item factories in the first block and item tutorials, which is how Mojang does it since 1.21.4, and avoids needing to repeat the registry key in the registration.

Also cleaned up a couple of other registration things I found while exploring the codebase.