### PR TITLE
Fix inconsistency in latest/FabricDocsReferenceAdvancementProvider.java

### DIFF
--- a/reference/latest/src/client/java/com/example/docs/datagen/FabricDocsReferenceAdvancementProvider.java
+++ b/reference/latest/src/client/java/com/example/docs/datagen/FabricDocsReferenceAdvancementProvider.java
@@ -64,7 +64,7 @@ public class FabricDocsReferenceAdvancementProvider extends FabricAdvancementPro
 						true,
 						false
 				)
-				.criterion("ate_apple", ConsumeItemCriterion.Conditions.item(wrapperLookup.getOrThrow(RegistryKeys.ITEM), Items.APPLE))
+				.criterion("ate_apple", ConsumeItemCriterion.Conditions.item(itemLookup, Items.APPLE))
 				.criterion("ate_cooked_beef", ConsumeItemCriterion.Conditions.item(itemLookup, Items.COOKED_BEEF))
 				.build(consumer, FabricDocsReference.MOD_ID + ":apple_and_beef");
 		// :::datagen-advancements:second-advancement


### PR DESCRIPTION
Was scrolling through [this page](https://docs.fabricmc.net/develop/data-generation/advancements) and noticed the following [code snippet](https://docs.fabricmc.net/develop/data-generation/advancements#one-more-example) initialized a variable like so:
```
final RegistryWrapper.Impl<Item> itemLookup = wrapperLookup.getOrThrow(RegistryKeys.ITEM);
```
then used it in registering the Advancement like so:
```
		.criterion("ate_apple", ConsumeItemCriterion.Conditions.item(wrapperLookup.getOrThrow(RegistryKeys.ITEM), Items.APPLE))
		.criterion("ate_cooked_beef", ConsumeItemCriterion.Conditions.item(itemLookup, Items.COOKED_BEEF))
```
Only using `itemLookup` for the second criterion when it could have also used it for the first criterion.