### PR TITLE
Add missing closing bracket in Creating Your First Item

### DIFF
--- a/reference/latest/src/main/java/com/example/docs/item/ModItems.java
+++ b/reference/latest/src/main/java/com/example/docs/item/ModItems.java
@@ -192,5 +192,6 @@ public class ModItems {
 	}
 
 	// :::3
+	// :::1
 }
 // :::1


### PR DESCRIPTION
Update ModItems.java and add :::1 to add the closing bracket for the sample code in first-item.md, at line 25.

The sample code in first-item.md, at line 25, lacks its closing bracket and causes a compilation error. The proposed change adds the :::1 at line 195 to add the missing closing bracket.

For more information about the issue, please refer to the documentation link at https://docs.fabricmc.net/develop/items/first-item

![image](https://github.com/user-attachments/assets/96f20ae5-d37e-40dc-ae39-73028510bb03)
