### PR TITLE
Correct Crowdin url

### DIFF
--- a/.vitepress/i18n.ts
+++ b/.vitepress/i18n.ts
@@ -343,9 +343,9 @@ function generateTranslatedThemeConfig(localeCode: string): Fabric.ThemeConfig {
       },
       {
         icon: "crowdin",
-        link:
-          "https://crowdin.com/project/fabricmc" +
-          (localeCode === "root" ? "" : `/${localeCode}`),
+        link: `https://crowdin.com/project/fabricmc/${
+          crowdinCode(localeCode) ?? ""
+        }`,
         ariaLabel: websiteResolver("social.crowdin"),
       },
     ],

--- a/develop/networking.md
+++ b/develop/networking.md
@@ -191,7 +191,7 @@ Finally, we create a `LightningEntity` and add it to the world.
 Now, if you add this mod to a server and when a player uses our Lightning Tater item, every player will see lightning
 striking at the user's position.
 
-<VideoPlayer src="/assets/develop/networking/summon-lightning.webm" title="Summon lightning using Lightning Tater" />
+<VideoPlayer src="/assets/develop/networking/summon-lightning.webm">Summon lightning using Lightning Tater</VideoPlayer>
 
 ### Sending a Packet to the Server {#sending-a-packet-to-the-server}
 
@@ -249,4 +249,4 @@ player to 5.
 
 Now when any player tries to use a Poisonous Potato on a living entity, the glowing effect will be applied to it.
 
-<VideoPlayer src="/assets/develop/networking/use-poisonous-potato.webm" title="Glowing effect is applied when a Poisonous Potato is used on a living entity." />
+<VideoPlayer src="/assets/develop/networking/use-poisonous-potato.webm">Glowing effect is applied when a Poisonous Potato is used on a living entity</VideoPlayer>


### PR DESCRIPTION
I wrongly used the `localeCode`, which is not the `crowdinCode`. See line 274:
<https://github.com/FabricMC/fabric-docs/blob/75999249812f89a277690f92af3aee5cdf6f93f3/.vitepress/i18n.ts#L274>