### PR TITLE
Project location

### DIFF
--- a/develop/getting-started/creating-a-project.md
+++ b/develop/getting-started/creating-a-project.md
@@ -28,7 +28,7 @@ You should extract this zip file to a location of your choice, and then open the
 ![Open Project Prompt](/assets/develop/getting-started/open-project.png)
 
 ::: warning
-You should follow these rules when choosing the path to your project: 
+You should follow these rules when choosing the path to your project:
 
 - Avoid cloud storage directories (for example Microsoft Onedrive)
 - Avoid non-ASCII characters (for example emoji, accented letters)

--- a/develop/getting-started/creating-a-project.md
+++ b/develop/getting-started/creating-a-project.md
@@ -28,7 +28,13 @@ You should extract this zip file to a location of your choice, and then open the
 ![Open Project Prompt](/assets/develop/getting-started/open-project.png)
 
 ::: warning
-Do not create your project folder in a cloud storage directory (for example, OneDrive), and avoid using paths with non-ASCII characters.
+You should follow these rules when choosing the path to your project: 
+
+- Avoid cloud storage directories (for example Microsoft Onedrive)
+- Avoid non-ASCII characters (for example emoji, accented letters)
+- Avoid spaces
+
+An example of a "good" path may be: `C:\Projects\YourProjectName`
 :::
 
 ## Importing the Project {#importing-the-project}

--- a/develop/getting-started/creating-a-project.md
+++ b/develop/getting-started/creating-a-project.md
@@ -27,6 +27,10 @@ You should extract this zip file to a location of your choice, and then open the
 
 ![Open Project Prompt](/assets/develop/getting-started/open-project.png)
 
+::: warning
+Do not create your project folder in a cloud storage directory (for example, OneDrive), and avoid using paths with non-ASCII characters.
+:::
+
 ## Importing the Project {#importing-the-project}
 
 Once you've opened the project in IntelliJ IDEA, the IDE should automatically load the project's Gradle configuration and perform the necessary setup tasks.

--- a/develop/getting-started/creating-a-project.md
+++ b/develop/getting-started/creating-a-project.md
@@ -5,6 +5,7 @@ authors:
   - Cactooz
   - IMB11
   - radstevee
+  - Thomas1034
 ---
 
 Fabric provides an easy way to create a new mod project using the Fabric Template Mod Generator - if you want, you can manually create a new project using the example mod repository, you should refer to the [Manual Project Creation](#manual-project-creation) section.


### PR DESCRIPTION
Adds a warning to avoid creating a project in a cloud storage directory, like OneDrive, or with a non-ASCII file path. 

In response to Qendolin's request on the Fabric Discord server, [here](https://discord.com/channels/507304429255393322/807617284129423370/1367301359212167299).