### PR TITLE
Add Modded Items to Minecraft Tags

### DIFF
--- a/reference/latest/src/main/generated/data/minecraft/tags/item/chest_armor.json
+++ b/reference/latest/src/main/generated/data/minecraft/tags/item/chest_armor.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "fabric-docs-reference:guidite_chestplate"
+  ]
+}

--- a/reference/latest/src/main/generated/data/minecraft/tags/item/foot_armor.json
+++ b/reference/latest/src/main/generated/data/minecraft/tags/item/foot_armor.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "fabric-docs-reference:guidite_boots"
+  ]
+}

--- a/reference/latest/src/main/generated/data/minecraft/tags/item/head_armor.json
+++ b/reference/latest/src/main/generated/data/minecraft/tags/item/head_armor.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "fabric-docs-reference:guidite_helmet"
+  ]
+}

--- a/reference/latest/src/main/generated/data/minecraft/tags/item/leg_armor.json
+++ b/reference/latest/src/main/generated/data/minecraft/tags/item/leg_armor.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "fabric-docs-reference:guidite_leggings"
+  ]
+}

--- a/reference/latest/src/main/generated/data/minecraft/tags/item/swords.json
+++ b/reference/latest/src/main/generated/data/minecraft/tags/item/swords.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "fabric-docs-reference:guidite_sword"
+  ]
+}


### PR DESCRIPTION
otherwise modded items cannot be enchanted properly and swords won't trigger sweeping attacks