### PR TITLE
Slight Improvements on the First Item to Highlight Texture, Model and Item Model Definition Usage

### DIFF
--- a/develop/blocks/first-block.md
+++ b/develop/blocks/first-block.md
@@ -22,7 +22,7 @@ Mojang does something extremely similar like this with vanilla blocks; you can r
 
 Just like with items, you need to ensure that the class is loaded so that all static fields containing your block instances are initialized.
 
-You can do this by creating a dummy `initialize` method, which can be called in your [mod's initializer](./getting-started/project-structure#entrypoints) to trigger the static initialization.
+You can do this by creating a dummy `initialize` method, which can be called in your [mod's initializer](../getting-started/project-structure#entrypoints) to trigger the static initialization.
 
 ::: info
 If you are unaware of what static initialization is, it is the process of initializing static fields in a class. This is done when the class is loaded by the JVM, and is done before any instances of the class are created.

--- a/develop/items/first-item.md
+++ b/develop/items/first-item.md
@@ -88,13 +88,23 @@ Create a new JSON file at: `src/main/resources/assets/mod-id/lang/en_us.json` an
 
 You can either restart the game or build your mod and press <kbd>F3</kbd>+<kbd>T</kbd> to apply changes.
 
-## Adding a Texture and Model {#adding-a-texture-and-model}
+## Adding an Item Model Description, Texture and Model {#adding-a-item-model-definition-texture-and-model}
+
+For your item to have a proper appearance, it requires:
+
+- [An item texture](https://minecraft.wiki/w/Textures#Items)
+- [An item model](https://minecraft.wiki/w/Model#Item_models)
+- [An item model description](https://minecraft.wiki/w/Items_model_definition)
+
+### Adding a Texture {#adding-a-texture}
 
 To give your item a texture and model, simply create a 16x16 texture image for your item and save it in the `assets/mod-id/textures/item` folder. Name the texture file the same as the item's identifier, but with a `.png` extension.
 
 For example purposes, you can use this example texture for `suspicious_substance.png`
 
 <DownloadEntry visualURL="/assets/develop/items/first_item_1.png" downloadURL="/assets/develop/items/first_item_1_small.png">Texture</DownloadEntry>
+
+### Adding a Model {#adding-a-model}
 
 When restarting/reloading the game - you should see that the item still has no texture, that's because you will need to add a model that uses this texture.
 
@@ -104,7 +114,7 @@ Create the model JSON in the `assets/mod-id/models/item` folder, with the same n
 
 @[code](@/reference/latest/src/main/generated/assets/fabric-docs-reference/models/item/suspicious_substance.json)
 
-### Breaking Down the Model JSON {#breaking-down-the-model-json}
+#### Breaking Down the Model JSON {#breaking-down-the-model-json}
 
 - `parent`: This is the parent model that this model will inherit from. In this case, it's the `item/generated` model.
 - `textures`: This is where you define the textures for the model. The `layer0` key is the texture that the model will use.
@@ -113,7 +123,7 @@ Most items will use the `item/generated` model as their parent, as it's a simple
 
 There are alternatives, such as `item/handheld` which is used for items that are "held" in the player's hand, such as tools.
 
-## Creating the Item Model Description {#creating-the-item-model-description}
+### Creating the Item Model Description {#creating-the-item-model-description}
 
 Minecraft doesn't automatically know where your items' model files can be found, we need to provide an item model description.
 
@@ -121,7 +131,7 @@ Create the item description JSON in the `assets/mod-id/items`, with the same fil
 
 @[code](@/reference/latest/src/main/generated/assets/fabric-docs-reference/items/suspicious_substance.json)
 
-### Breaking Down the Item Model Description JSON {#breaking-down-the-item-model-description-json}
+#### Breaking Down the Item Model Description JSON {#breaking-down-the-item-model-description-json}
 
 - `model`: This is the property that contains the reference to our model.
   - `type`: This is the type of our model. For most items, this should be `minecraft:model`


### PR DESCRIPTION
People quite often miss that a texture, model, and an item model definition are required for an item to have its proper appearance in game.

This change highlights that all 3 are required. Additionally, they link to the Minecraft Wiki for an in-depth explanation.

I have also rearranged the headings a bit to further support the above changes.

There's also a link fix in the First Block page.