### PR TITLE
replace remaining mentions of tickDelta with tickProgress

### DIFF
--- a/develop/rendering/hud.md
+++ b/develop/rendering/hud.md
@@ -28,7 +28,7 @@ The draw context can be used to access the various rendering utilities provided 
 
 The `RenderTickCounter` class allows you to retrieve the current `tickProgress` value. `tickProgress` is the "progress" between the last game tick and the next game tick.
 
-For example, if we assume a 200 FPS scenario, the game runs a new tick roughly every 10 frames. Each frame, `tickDelta` represents how far we are between the last tick and the next. Over 11 frames, you might see:
+For example, if we assume a 200 FPS scenario, the game runs a new tick roughly every 10 frames. Each frame, `tickProgress` represents how far we are between the last tick and the next. Over 11 frames, you might see:
 
 | Frame | `tickProgress` |
 |:-----:|----------------|
@@ -54,4 +54,4 @@ In this example, we'll use `Util.getMeasuringTimeMs()` to linearly interpolate t
 
 ![Lerping a color over time](/assets/develop/rendering/hud-rendering-deltatick.webp)
 
-Why don't you try use `tickDelta` and see what happens to the animation when you run the `/tick freeze` command? You should see the animation freeze in place as `tickDelta` becomes constant (assuming you have passed `false` as the parameter to `RenderTickCounter#getTickDelta`)
+Why don't you try use `tickProgress` and see what happens to the animation when you run the `/tick freeze` command? You should see the animation freeze in place as `tickProgress` becomes constant (assuming you have passed `false` as the parameter to `RenderTickCounter#getTickProgress`)


### PR DESCRIPTION
replaced remaining mentions of `tickDelta` and `RenderTickCounter#getTickDelta` with `tickProgress` and `RenderTickCounter#getTickProgress` respectively on the hud rendering page