### PR TITLE
Update rendering concepts page

### DIFF
--- a/.vitepress/sidebars/develop.ts
+++ b/.vitepress/sidebars/develop.ts
@@ -172,11 +172,10 @@ export default [
     text: "develop.rendering",
     collapsed: true,
     items: [
-      // TODO: Enable this page once the reference mod is fixed.
-      // {
-      //   text: "develop.rendering.basicConcepts",
-      //   link: "/develop/rendering/basic-concepts",
-      // },
+      {
+        text: "develop.rendering.basicConcepts",
+        link: "/develop/rendering/basic-concepts",
+      },
       {
         text: "develop.rendering.drawContext",
         link: "/develop/rendering/draw-context",

--- a/develop/rendering/basic-concepts.md
+++ b/develop/rendering/basic-concepts.md
@@ -12,6 +12,14 @@ Although Minecraft is built using OpenGL, as of version 1.17+ you cannot use leg
 To summarize, you have to use Minecraft's rendering system, or build your own that utilizes `GL.glDrawElements()`.
 :::
 
+::: warning IMPORTANT UPDATE FOR 1.21.8+
+Since 1.21.6, large changes are being implemented to the rendering pipeline, such as moving towards `RenderLayer`s and `RenderPipeline`s and more importantly, `RenderState`s, with the ultimate goal of being able to "prepare" the next frame while drawing the current frame. In the "preparation" phase, all game data used for rendering is extracted to `RenderState`s, so another thread can work on drawing that frame while the next frame is being extracted.
+
+For example, in 1.21.8, GUI rendering adopted this model, and `DrawContext` methods simply add to the render state. Actual uploading to the `BufferBuilder` happens at the end of the "prepare" phase, after all elements have been added to the `RenderState`. See `GuiRenderer#prepare`.
+
+This article covers the basics of rendering and should still be relevant, but most of the time, there are higher level abstractions that you can use for better performance and compatibility.
+:::
+
 This page will cover the basics of rendering using the new system, going over key terminology and concepts.
 
 Although much of rendering in Minecraft is abstracted through the various `DrawContext` methods, and you'll likely not need to touch anything mentioned here, it's still important to understand the basics of how rendering works.
@@ -109,6 +117,14 @@ This should give us a lovely diamond - since we're using the `TRIANGLE_STRIP` dr
 
 Since we're drawing on the HUD in this example, we'll use the `HudElementRegistry`:
 
+::: warning IMPORTANT UPDATE FOR 1.21.8+
+Since Minecraft 1.21.8, the matrix stack passed for HUD rendering has been changed from `MatrixStack` to `Matrix3x2fStack`. Most methods are slightly different and no longer take a `z` parameter, but the concepts are the same.
+
+Additionally, the example code below is detached from the explanation above, since you do not need to manually write to the `BufferBuilder`. `DrawContext` methods automatically writes to the HUD's `BufferBuilder` for you during preparation.
+
+See the important update at the beginning of this page for more information.
+:::
+
 @[code lang=java transcludeWith=:::1](@/reference/latest/src/client/java/com/example/docs/rendering/RenderingConceptsEntrypoint.java)
 
 This results in the following being drawn on the HUD:
@@ -120,6 +136,10 @@ Try mess around with the colors and positions of the vertices to see what happen
 :::
 
 ## The `MatrixStack` {#the-matrixstack}
+
+::: warning IMPORTANT UPDATE FOR 1.21.8+
+The code example for this section uses `Matrix3x2fStack`, which is used for HUD rendering since 1.21.8. The methods are slightly different. See the important update above for more information.
+:::
 
 After learning how to write to the `BufferBuilder`, you might be wondering how to transform your model - or even animate it. This is where the `MatrixStack` class comes in.
 
@@ -147,11 +167,15 @@ Make sure to push the matrix stack before you get a transformation matrix!
 
 ## Quaternions (Rotating Things) {#quaternions-rotating-things}
 
+::: warning IMPORTANT UPDATE FOR 1.21.8+
+Similar to above, the code example is slightly different than the explanation. The explanation discusses rendering in 3D world space, while the code example renders on the HUD.
+:::
+
 Quaternions are a way of representing rotations in 3D space. They are used to rotate the top matrix on the `MatrixStack` via the `multiply(Quaternion, x, y, z)` method.
 
 It's highly unlikely you'll need to ever use a Quaternion class directly, since Minecraft provides various pre-built Quaternion instances in it's `RotationAxis` utility class.
 
-Let's say we want to rotate our diamond around the z-axis. We can do this by using the `MatrixStack` and the `multiply(Quaternion, x, y, z)` method.
+Let's say we want to rotate our square around the z-axis. We can do this by using the `MatrixStack` and the `multiply(Quaternion, x, y, z)` method.
 
 @[code lang=java transcludeWith=:::3](@/reference/latest/src/client/java/com/example/docs/rendering/RenderingConceptsEntrypoint.java)
 

--- a/develop/rendering/basic-concepts.md
+++ b/develop/rendering/basic-concepts.md
@@ -12,12 +12,12 @@ Although Minecraft is built using OpenGL, as of version 1.17+ you cannot use leg
 To summarize, you have to use Minecraft's rendering system, or build your own that utilizes `GL.glDrawElements()`.
 :::
 
-::: warning IMPORTANT UPDATE FOR 1.21.8+
-Since 1.21.6, large changes are being implemented to the rendering pipeline, such as moving towards `RenderLayer`s and `RenderPipeline`s and more importantly, `RenderState`s, with the ultimate goal of being able to "prepare" the next frame while drawing the current frame. In the "preparation" phase, all game data used for rendering is extracted to `RenderState`s, so another thread can work on drawing that frame while the next frame is being extracted.
+::: warning IMPORTANT UPDATE
+Starting from 1.21.6, large changes are being implemented to the rendering pipeline, such as moving towards `RenderLayer`s and `RenderPipeline`s and more importantly, `RenderState`s, with the ultimate goal of being able to prepare the next frame while drawing the current frame. In the "preparation" phase, all game data used for rendering is extracted to `RenderState`s, so another thread can work on drawing that frame while the next frame is being extracted.
 
-For example, in 1.21.8, GUI rendering adopted this model, and `DrawContext` methods simply add to the render state. Actual uploading to the `BufferBuilder` happens at the end of the "prepare" phase, after all elements have been added to the `RenderState`. See `GuiRenderer#prepare`.
+For example, in 1.21.8 GUI rendering adopted this model, and `DrawContext` methods simply add to the render state. The actual uploading to the `BufferBuilder` happens at the end of the preparation phase, after all elements have been added to the `RenderState`. See `GuiRenderer#prepare`.
 
-This article covers the basics of rendering and should still be relevant, but most of the time, there are higher level abstractions that you can use for better performance and compatibility.
+This article covers the basics of rendering and, while still somewhat relevant, most times there are higher levels of abstractions for better performance and compatibility.
 :::
 
 This page will cover the basics of rendering using the new system, going over key terminology and concepts.
@@ -117,12 +117,12 @@ This should give us a lovely diamond - since we're using the `TRIANGLE_STRIP` dr
 
 Since we're drawing on the HUD in this example, we'll use the `HudElementRegistry`:
 
-::: warning IMPORTANT UPDATE FOR 1.21.8+
-Since Minecraft 1.21.8, the matrix stack passed for HUD rendering has been changed from `MatrixStack` to `Matrix3x2fStack`. Most methods are slightly different and no longer take a `z` parameter, but the concepts are the same.
+::: warning IMPORTANT UPDATE
+Starting from 1.21.8, the matrix stack passed for HUD rendering has been changed from `MatrixStack` to `Matrix3x2fStack`. Most methods are slightly different and no longer take a `z` parameter, but the concepts are the same.
 
-Additionally, the example code below is detached from the explanation above, since you do not need to manually write to the `BufferBuilder`. `DrawContext` methods automatically writes to the HUD's `BufferBuilder` for you during preparation.
+Additionally, the code below does not fully match the explanation above: you do not need to manually write to the `BufferBuilder`, because `DrawContext` methods automatically write to the HUD's `BufferBuilder` during preparation.
 
-See the important update at the beginning of this page for more information.
+Read the important update above for more information.
 :::
 
 @[code lang=java transcludeWith=:::1](@/reference/latest/src/client/java/com/example/docs/rendering/RenderingConceptsEntrypoint.java)
@@ -137,8 +137,12 @@ Try mess around with the colors and positions of the vertices to see what happen
 
 ## The `MatrixStack` {#the-matrixstack}
 
-::: warning IMPORTANT UPDATE FOR 1.21.8+
-The code example for this section uses `Matrix3x2fStack`, which is used for HUD rendering since 1.21.8. The methods are slightly different. See the important update above for more information.
+::: warning
+This section's code and the text are discussing different things!
+
+The code showcases `Matrix3x2fStack`, which is used for HUD rendering since 1.21.8, while the text describes `MatrixStack`, which has slightly different methods.
+
+Read the important update above for more information.
 :::
 
 After learning how to write to the `BufferBuilder`, you might be wondering how to transform your model - or even animate it. This is where the `MatrixStack` class comes in.
@@ -167,8 +171,12 @@ Make sure to push the matrix stack before you get a transformation matrix!
 
 ## Quaternions (Rotating Things) {#quaternions-rotating-things}
 
-::: warning IMPORTANT UPDATE FOR 1.21.8+
-Similar to above, the code example is slightly different than the explanation. The explanation discusses rendering in 3D world space, while the code example renders on the HUD.
+::: warning
+This section's code and the text are discussing different things!
+
+The code showcases rendering on the HUD, while the text describes rendering the 3D world space.
+
+Read the important update above for more information.
 :::
 
 Quaternions are a way of representing rotations in 3D space. They are used to rotate the top matrix on the `MatrixStack` via the `multiply(Quaternion, x, y, z)` method.

--- a/develop/rendering/hud.md
+++ b/develop/rendering/hud.md
@@ -5,10 +5,8 @@ authors:
   - IMB11
   - kevinthegreat1
 ---
-<!-- TODO: Enable this paragraph once the reference mod is fixed. -->
-<!-- We already briefly touched on rendering things to the HUD in the [Basic Rendering Concepts](./basic-concepts) page and [Using The Drawing Context](./draw-context), so on this page we'll stick to the Hud API and the `RenderTickCounter` parameter. -->
 
-We already briefly touched on rendering things to the HUD in [Using The Drawing Context](./draw-context), so on this page we'll stick to the Hud API and the `RenderTickCounter` parameter.
+We already briefly touched on rendering things to the HUD in the [Basic Rendering Concepts](./basic-concepts) page and [Using The Drawing Context](./draw-context), so on this page we'll stick to the Hud API and the `RenderTickCounter` parameter.
 
 ## `HudRenderCallback` {#hudrendercallback}
 

--- a/reference/latest/src/client/java/com/example/docs/rendering/RenderingConceptsEntrypoint.java
+++ b/reference/latest/src/client/java/com/example/docs/rendering/RenderingConceptsEntrypoint.java
@@ -1,6 +1,9 @@
 package com.example.docs.rendering;
 
+import org.joml.Matrix3x2fStack;
+
 import net.minecraft.util.Identifier;
+import net.minecraft.util.math.MathHelper;
 
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElement;
@@ -21,21 +24,19 @@ public class RenderingConceptsEntrypoint implements ClientModInitializer {
 
 	private HudElement hudLayer() {
 		return (drawContext, tickCounter) -> {
-			// TODO: fix advanced hud rendering example
-			/*
 			// :::1
 			if (false) {
 				return;
 			}
 
 			// :::2
-			MatrixStack matrices = drawContext.getMatrices();
+			Matrix3x2fStack matrices = drawContext.getMatrices();
 
 			// Store the total tick delta in a field, so we can use it later.
 			totalTickProgress += tickCounter.getTickProgress(true);
 
 			// Push a new matrix onto the stack.
-			matrices.push();
+			matrices.pushMatrix();
 			// :::2
 
 			// :::2
@@ -44,36 +45,29 @@ public class RenderingConceptsEntrypoint implements ClientModInitializer {
 
 			// Apply the scaling amount to the matrix.
 			// We don't need to scale the Z axis since it's on the HUD and 2D.
-			matrices.scale(scaleAmount, scaleAmount, 1F);
+			matrices.scale(scaleAmount, scaleAmount);
 			// :::2
-			matrices.scale(1 / scaleAmount, 1 / scaleAmount, 1F);
-			matrices.translate(60f, 60f, 0f);
+			matrices.scale(1 / scaleAmount, 1 / scaleAmount);
+			matrices.translate(60f, 60f);
 			// :::3
 			// Lerp between 0 and 360 degrees over time.
-			float rotationAmount = (float) (totalTickProgress / 50F % 360);
-			matrices.multiply(RotationAxis.POSITIVE_Z.rotation(rotationAmount));
-			// Shift entire diamond so that it rotates in its center.
-			matrices.translate(-20f, -40f, 0f);
+			float rotationAmount = totalTickProgress / 50F % 360;
+			matrices.rotate(rotationAmount);
+			// Shift entire square so that it rotates in its center.
+			matrices.translate(-20f, -40f);
 			// :::3
 
 			// :::1
-			drawContext.draw(vertexConsumerProvider -> {
-				VertexConsumer buffer = vertexConsumerProvider.getBuffer(RenderLayer.getGui());
-				buffer.vertex(20, 20, 5).color(0xFF414141);
-				buffer.vertex(5, 40, 5).color(0xFF000000);
-				buffer.vertex(35, 40, 5).color(0xFF000000);
-				buffer.vertex(20, 60, 5).color(0xFF414141);
-			});
+			drawContext.fillGradient(5, 20, 35, 60, 0xFF414141, 0xFF000000);
 			// :::1
 			// :::2
 
-			// ... write to the buffer.
+			// We do not need to manually write to the buffer. DrawContext methods write to GUI buffer in `GuiRenderer` at the end of preparation.
 
 			// Pop our matrix from the stack.
-			matrices.pop();
+			matrices.popMatrix();
 			// :::2
 			// :::1
-			 */
 		};
 	}
 }


### PR DESCRIPTION
I've updated the code. It's still a bit confusing, but it should be at least correct and guide people on where to look.

<img width="966" height="620" alt="Working impl of rendering concepts in 1.21.8" src="https://github.com/user-attachments/assets/87c784ae-c9ba-4053-a32b-950ccd4d51f1" />
