### PR TITLE
Notes on Creating a Project

### DIFF
--- a/develop/getting-started/setting-up-intellij-idea.md
+++ b/develop/getting-started/setting-up-intellij-idea.md
@@ -44,3 +44,7 @@ Although this plugin isn't strictly necessary, it can make modding with Fabric m
 You can install it by opening IntelliJ IDEA, and then navigating to **File** > **Settings** > **Plugins** > **Marketplace** tab, then search for `Minecraft Development` in the search bar, and click the **Install** button.
 
 Alternatively, you can download it from the [plugin page](https://plugins.jetbrains.com/plugin/8327-minecraft-development) and then install it by navigating to **File** > **Settings** > **Plugins** > **Install Plugin From Disk**.
+
+## Creating a Project {#creating-a-project}
+
+While it is possible to create a project using IntelliJ Idea's "Minecraft Development" plugin, this is not recommended as the templates are often out of date. We recommend moving on to [Creating a Project](./creating-a-project) to use the Fabric Template Mod Generator.


### PR DESCRIPTION
New users are prone to skipping ahead and attempting to create a project through IntelliJ Idea. This causes issues, as Minecraft Development's plugins are not always kept up to date (see recent posts in the Fabric Discord confused why unpick isn't working). New users should be recommended toward the existing tutorial.