### PR TITLE
fix image z-index

### DIFF
--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -109,7 +109,7 @@
   z-index: 10000;
 }
 
-.medium-zoom-image {
+.medium-zoom-image--opened {
   z-index: 10001;
 }
 


### PR DESCRIPTION
Based on [medium-zoom's README](https://github.com/francoischalifour/medium-zoom/blob/35b519fbdef97df69cc1d7daf46988effef0860b/README.md#the-zoomed-image-is-not-visible)


|Before|After|
|:-:|:-:|
| <img width="2560" height="1408" alt="Screenshot From 2025-10-12 01-06-59" src="https://github.com/user-attachments/assets/ade71204-8f3e-49b0-a7d1-5281dd1bf9e4" /> | <img width="2560" height="1408" alt="Screenshot From 2025-10-12 01-07-48" src="https://github.com/user-attachments/assets/e12ee2fa-cff3-4819-8cba-301ac6b68bb7" /> |

