### PR TITLE
format

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+max_line_length = 100
+trim_trailing_whitespace = true
+
+[*.java]
+indent_style = tab
+
+[*.bat]
+end_of_line = crlf

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -26,7 +26,7 @@ export default defineVersionedConfig(
     locales: loadLocales(__dirname),
 
     markdown: {
-      config(md) {
+      config: (md) => {
         // Use the snippet plugin (transclusion, etc.)
         md.use(snippetPlugin);
       },
@@ -42,7 +42,7 @@ export default defineVersionedConfig(
           }).then((lang) => ({ ...(lang.default as any), name: "mcfunction" })),
       ],
       lineNumbers: true,
-      async shikiSetup(shiki) {
+      shikiSetup: async (shiki) => {
         await shiki.loadTheme("github-light", "github-dark");
       },
     },
@@ -61,13 +61,12 @@ export default defineVersionedConfig(
     themeConfig: {
       search: {
         options: {
-          // Removes versioned and translated pages from search.
-          _render(src, env, md) {
-            if (env.frontmatter?.search === false) return "";
-            if (env.relativePath.startsWith("translated/")) return "";
-            if (env.relativePath.startsWith("versions/")) return "";
-            return md.render(src, env);
-          },
+          _render: (src, env, md) =>
+            env.frontmatter?.search === false ||
+            env.relativePath.startsWith("translated/") ||
+            env.relativePath.startsWith("versions/")
+              ? ""
+              : md.render(src, env),
         },
         provider: "local",
       },

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -1,7 +1,7 @@
 import snippetPlugin from "markdown-it-vuepress-code-snippet-enhanced";
 import defineVersionedConfig from "vitepress-versioning-plugin";
 
-import { loadLocales, processExistingEntries } from "./i18n";
+import { getLocales, processExistingEntries } from "./i18n";
 import { transformItems, transformPageData } from "./transform";
 
 // https://vitepress.dev/reference/site-config
@@ -23,7 +23,7 @@ export default defineVersionedConfig(
     // Reduce the size of the dist by using a separate js file for the metadata.
     metaChunk: true,
 
-    locales: loadLocales(__dirname),
+    locales: getLocales(),
 
     markdown: {
       config: (md) => {
@@ -62,9 +62,9 @@ export default defineVersionedConfig(
       search: {
         options: {
           _render: (src, env, md) =>
-            env.frontmatter?.search === false ||
-            env.relativePath.startsWith("translated/") ||
-            env.relativePath.startsWith("versions/")
+            env.frontmatter?.search === false
+            || env.relativePath.startsWith("translated/")
+            || env.relativePath.startsWith("versions/")
               ? ""
               : md.render(src, env),
         },

--- a/.vitepress/i18n.ts
+++ b/.vitepress/i18n.ts
@@ -7,7 +7,10 @@ import DevelopSidebar from "./sidebars/develop";
 import PlayersSidebar from "./sidebars/players";
 import { Fabric } from "./types";
 
-function getTranslationsResolver(localeFolder: string, fileName: string): (key: string) => string {
+const getTranslationsResolver = (
+  localeFolder: string,
+  fileName: string
+): ((key: string) => string) => {
   const file = resolve(
     __dirname,
     "..",
@@ -25,13 +28,15 @@ function getTranslationsResolver(localeFolder: string, fileName: string): (key: 
   } else {
     return (key: string) => strings[key] || getTranslationsResolver("root", fileName)(key);
   }
-}
-export const getWebsiteResolver = (localeFolder: string) =>
-  getTranslationsResolver(localeFolder, "website_translations.json");
-export const getSidebarResolver = (localeFolder: string) =>
+};
+
+const getSidebarResolver = (localeFolder: string) =>
   getTranslationsResolver(localeFolder, "sidebar_translations.json");
 
-export function processExistingEntries(sidebar: Versioned.Sidebar): Versioned.Sidebar {
+export const getWebsiteResolver = (localeFolder: string) =>
+  getTranslationsResolver(localeFolder, "website_translations.json");
+
+export const processExistingEntries = (sidebar: Versioned.Sidebar): Versioned.Sidebar => {
   // Get locales from __dirname/../translated/* folder names.
   const localeFolders = readdirSync(resolve(__dirname, "..", "translated"), {
     withFileTypes: true,
@@ -82,12 +87,12 @@ export function processExistingEntries(sidebar: Versioned.Sidebar): Versioned.Si
   }
 
   return sidebar;
-}
+};
 
-export function getLocalizedSidebar(
+const getLocalizedSidebar = (
   sidebar: Fabric.SidebarItem[],
   localeCode: string
-): Fabric.SidebarItem[] {
+): Fabric.SidebarItem[] => {
   const sidebarResolver = getSidebarResolver(localeCode);
   const localizedSidebar = JSON.parse(JSON.stringify(sidebar));
 
@@ -108,7 +113,7 @@ export function getLocalizedSidebar(
   }
 
   return localizedSidebar;
-}
+};
 
 /**
  * Generates translated sidebars for a given root directory and sidebars.
@@ -117,10 +122,10 @@ export function getLocalizedSidebar(
  * @param dirname - The root directory to generate translated sidebars for.
  * @returns An object containing translated sidebars, keyed by locale URL.
  */
-export function generateTranslatedSidebars(
+const generateTranslatedSidebars = (
   sidebars: { [url: string]: Fabric.SidebarItem[] },
   dirname: string
-): { [localeUrl: string]: Fabric.SidebarItem[] } {
+): { [localeUrl: string]: Fabric.SidebarItem[] } => {
   const translatedSidebars: { [key: string]: Fabric.SidebarItem[] } = {};
 
   for (const key of Object.keys(sidebars)) {
@@ -140,7 +145,7 @@ export function generateTranslatedSidebars(
   }
 
   return translatedSidebars;
-}
+};
 
 /**
  * Generates a theme configuration for a given locale.
@@ -148,7 +153,7 @@ export function generateTranslatedSidebars(
  * @param localeCode - The code of the locale ("root" for English).
  * @returns A theme configuration object.
  */
-function generateTranslatedThemeConfig(localeCode: string): Fabric.ThemeConfig {
+const generateTranslatedThemeConfig = (localeCode: string): Fabric.ThemeConfig => {
   const websiteResolver = getWebsiteResolver(localeCode);
 
   const crowdinCode = (localeCode: string): string | null => {
@@ -333,7 +338,7 @@ function generateTranslatedThemeConfig(localeCode: string): Fabric.ThemeConfig {
 
     versionSwitcher: false,
   };
-}
+};
 
 /**
  * Loads locales and generates a LocaleConfig object.
@@ -341,7 +346,7 @@ function generateTranslatedThemeConfig(localeCode: string): Fabric.ThemeConfig {
  * @param dirname - The root directory of the project.
  * @returns A LocaleConfig object with locales and their corresponding themeConfig.
  */
-export function loadLocales(dirname: string): LocaleConfig<Fabric.ThemeConfig> {
+export const loadLocales = (dirname: string): LocaleConfig<Fabric.ThemeConfig> => {
   const translatedFolder = resolve(dirname, "..", "translated");
   const localeFolders = readdirSync(translatedFolder, { withFileTypes: true })
     .filter((dirent) => dirent.isDirectory())
@@ -401,4 +406,4 @@ export function loadLocales(dirname: string): LocaleConfig<Fabric.ThemeConfig> {
   }
 
   return locales;
-}
+};

--- a/.vitepress/i18n.ts
+++ b/.vitepress/i18n.ts
@@ -215,7 +215,10 @@ const translateThemeConfig = (locale: string): Fabric.ThemeConfig => {
     logo: "/logo.png",
 
     nav: [
-      { text: resolver("nav.home"), link: "https://fabricmc.net/" },
+      {
+        text: resolver("nav.home"),
+        link: "https://fabricmc.net/",
+      },
       {
         text: resolver("nav.download"),
         link: "https://fabricmc.net/use",
@@ -223,7 +226,7 @@ const translateThemeConfig = (locale: string): Fabric.ThemeConfig => {
       {
         text: resolver("nav.contribute"),
         items: [
-          // TODO: Expand on this later, with guidelines for loader+loom potentially?
+          // TODO: Expand on this later, with guidelines for loader & loom potentially?
           {
             text: resolver("title"),
             link: `${locale === "root" ? "" : `/${locale}`}/contributing`,

--- a/.vitepress/i18n.ts
+++ b/.vitepress/i18n.ts
@@ -3,42 +3,32 @@ import { resolve } from "path/posix";
 import { LocaleConfig } from "vitepress";
 import { Versioned } from "vitepress-versioning-plugin";
 
-import DevelopSidebar from "./sidebars/develop";
-import PlayersSidebar from "./sidebars/players";
+import Develop from "./sidebars/develop";
+import Players from "./sidebars/players";
 import { Fabric } from "./types";
 
-const getTranslationsResolver = (
-  localeFolder: string,
-  fileName: string
-): ((key: string) => string) => {
-  const file = resolve(
-    __dirname,
-    "..",
-    "translated",
-    localeFolder === "root" ? ".." : localeFolder,
-    fileName
-  );
+const getResolver = (locale: string, fileName: string): ((k: string) => string) => {
+  const file = resolve(__dirname, "..", "translated", locale === "root" ? ".." : locale, fileName);
 
-  const strings: { [key: string]: string } = existsSync(file)
+  const strings: Record<string, string> = existsSync(file)
     ? JSON.parse(readFileSync(file, "utf-8"))
     : {};
 
-  if (localeFolder === "root") {
-    return (key: string) => strings[key] || key;
+  if (locale === "root") {
+    return (k: string) => strings[k] || k;
   } else {
-    return (key: string) => strings[key] || getTranslationsResolver("root", fileName)(key);
+    return (k: string) => strings[k] || getResolver("root", fileName)(k);
   }
 };
 
-const getSidebarResolver = (localeFolder: string) =>
-  getTranslationsResolver(localeFolder, "sidebar_translations.json");
+const getSidebarResolver = (locale: string) => getResolver(locale, "sidebar_translations.json");
 
-export const getWebsiteResolver = (localeFolder: string) =>
-  getTranslationsResolver(localeFolder, "website_translations.json");
+export const getWebsiteResolver = (locale: string) =>
+  getResolver(locale, "website_translations.json");
 
 export const processExistingEntries = (sidebar: Versioned.Sidebar): Versioned.Sidebar => {
   // Get locales from __dirname/../translated/* folder names.
-  const localeFolders = readdirSync(resolve(__dirname, "..", "translated"), {
+  const locales = readdirSync(resolve(__dirname, "..", "translated"), {
     withFileTypes: true,
   })
     .filter((dirent) => dirent.isDirectory())
@@ -52,7 +42,7 @@ export const processExistingEntries = (sidebar: Versioned.Sidebar): Versioned.Si
     return (
       !key.includes("/players")
       && !key.includes("/develop")
-      && localeFolders.some((locale) => key.includes(locale))
+      && locales.some((locale) => key.includes(locale))
     );
   });
 
@@ -91,9 +81,9 @@ export const processExistingEntries = (sidebar: Versioned.Sidebar): Versioned.Si
 
 const getLocalizedSidebar = (
   sidebar: Fabric.SidebarItem[],
-  localeCode: string
+  locale: string
 ): Fabric.SidebarItem[] => {
-  const sidebarResolver = getSidebarResolver(localeCode);
+  const resolver = getSidebarResolver(locale);
   const localizedSidebar = JSON.parse(JSON.stringify(sidebar));
 
   for (const item of localizedSidebar) {
@@ -101,14 +91,14 @@ const getLocalizedSidebar = (
       continue;
     }
 
-    item.text = sidebarResolver(item.text);
+    item.text = resolver(item.text);
 
-    if (item.link && localeCode !== "root" && item.process !== false) {
-      item.link = `/${localeCode}${item.link}`;
+    if (item.link && locale !== "root" && item.process !== false) {
+      item.link = `/${locale}${item.link}`;
     }
 
     if (item.items) {
-      item.items = getLocalizedSidebar(item.items, localeCode);
+      item.items = getLocalizedSidebar(item.items, locale);
     }
   }
 
@@ -119,21 +109,19 @@ const getLocalizedSidebar = (
  * Generates translated sidebars for a given root directory and sidebars.
  *
  * @param sidebars - An object containing sidebars to translate, keyed by URL.
- * @param dirname - The root directory to generate translated sidebars for.
  * @returns An object containing translated sidebars, keyed by locale URL.
  */
-const generateTranslatedSidebars = (
-  sidebars: { [url: string]: Fabric.SidebarItem[] },
-  dirname: string
-): { [localeUrl: string]: Fabric.SidebarItem[] } => {
-  const translatedSidebars: { [key: string]: Fabric.SidebarItem[] } = {};
+const translateSidebars = (
+  sidebars: Record<string, Fabric.SidebarItem[]>
+): Record<string, Fabric.SidebarItem[]> => {
+  const translatedSidebars: Record<string, Fabric.SidebarItem[]> = {};
 
   for (const key of Object.keys(sidebars)) {
     const sidebar = sidebars[key];
     translatedSidebars[key] = getLocalizedSidebar(sidebar, "root");
   }
 
-  const translatedFolder = resolve(dirname, "..", "translated");
+  const translatedFolder = resolve(__dirname, "..", "translated");
 
   for (const folder of readdirSync(translatedFolder, { withFileTypes: true })
     .filter((dirent) => dirent.isDirectory())
@@ -150,11 +138,11 @@ const generateTranslatedSidebars = (
 /**
  * Generates a theme configuration for a given locale.
  *
- * @param localeCode - The code of the locale ("root" for English).
+ * @param locale - The code of the locale ("root" for English).
  * @returns A theme configuration object.
  */
-const generateTranslatedThemeConfig = (localeCode: string): Fabric.ThemeConfig => {
-  const websiteResolver = getWebsiteResolver(localeCode);
+const translateThemeConfig = (locale: string): Fabric.ThemeConfig => {
+  const resolver = getWebsiteResolver(locale);
 
   const crowdinCode = (localeCode: string): string | null => {
     // https://developer.crowdin.com/language-codes
@@ -176,72 +164,72 @@ const generateTranslatedThemeConfig = (localeCode: string): Fabric.ThemeConfig =
   return {
     // https://vitepress.dev/reference/default-theme-config
     authors: {
-      heading: websiteResolver("authors.heading"),
-      noGitHub: websiteResolver("authors.no_github"),
+      heading: resolver("authors.heading"),
+      noGitHub: resolver("authors.no_github"),
     },
 
     banner: {
-      text: websiteResolver("banner"),
-      discord: websiteResolver("social.discord"),
-      github: websiteResolver("social.github"),
+      text: resolver("banner"),
+      discord: resolver("social.discord"),
+      github: resolver("social.github"),
     },
 
-    darkModeSwitchLabel: websiteResolver("mode_switcher"),
+    darkModeSwitchLabel: resolver("mode_switcher"),
 
-    darkModeSwitchTitle: websiteResolver("mode_dark"),
+    darkModeSwitchTitle: resolver("mode_dark"),
 
     docFooter: {
-      next: websiteResolver("footer.next"),
-      prev: websiteResolver("footer.prev"),
+      next: resolver("footer.next"),
+      prev: resolver("footer.prev"),
     },
 
     download: {
-      text: websiteResolver("download"),
+      text: resolver("download"),
     },
 
     editLink: {
       pattern: "https://github.com/FabricMC/fabric-docs/edit/main/:path",
-      text: websiteResolver("github_edit"),
+      text: resolver("github_edit"),
     },
 
     externalLinkIcon: true,
 
     footer: {
-      copyright: websiteResolver("footer.copyright").replace(
+      copyright: resolver("footer.copyright").replace(
         "%s",
-        `<a href=\"https://github.com/FabricMC/fabric-docs/blob/main/LICENSE\" target=\"_blank\" rel=\"noreferrer\">${websiteResolver(
+        `<a href=\"https://github.com/FabricMC/fabric-docs/blob/main/LICENSE\" target=\"_blank\" rel=\"noreferrer\">${resolver(
           "footer.license"
         )}</a>`
       ),
-      message: websiteResolver("footer.message"),
+      message: resolver("footer.message"),
     },
 
-    langMenuLabel: websiteResolver("lang_switcher"),
+    langMenuLabel: resolver("lang_switcher"),
 
     lastUpdated: {
-      text: websiteResolver("last_updated"),
+      text: resolver("last_updated"),
     },
 
-    lightModeSwitchTitle: websiteResolver("mode_light"),
+    lightModeSwitchTitle: resolver("mode_light"),
 
     logo: "/logo.png",
 
     nav: [
-      { text: websiteResolver("nav.home"), link: "https://fabricmc.net/" },
+      { text: resolver("nav.home"), link: "https://fabricmc.net/" },
       {
-        text: websiteResolver("nav.download"),
+        text: resolver("nav.download"),
         link: "https://fabricmc.net/use",
       },
       {
-        text: websiteResolver("nav.contribute"),
+        text: resolver("nav.contribute"),
         items: [
           // TODO: Expand on this later, with guidelines for loader+loom potentially?
           {
-            text: websiteResolver("title"),
-            link: (localeCode === "root" ? "" : `/${localeCode}`) + "/contributing",
+            text: resolver("title"),
+            link: (locale === "root" ? "" : `/${locale}`) + "/contributing",
           },
           {
-            text: websiteResolver("nav.contribute.api"),
+            text: resolver("nav.contribute.api"),
             link: "https://github.com/FabricMC/fabric/blob/1.20.4/CONTRIBUTING.md",
           },
         ],
@@ -252,88 +240,82 @@ const generateTranslatedThemeConfig = (localeCode: string): Fabric.ThemeConfig =
     ],
 
     notFound: {
-      code: websiteResolver("404.code"),
-      title: websiteResolver("404.title"),
-      quote: websiteResolver("404.quote"),
+      code: resolver("404.code"),
+      title: resolver("404.title"),
+      quote: resolver("404.quote"),
 
-      crowdinCode: crowdinCode(localeCode),
-      crowdinLinkLabel: websiteResolver("404.crowdin_link.label"),
-      crowdinLinkText: websiteResolver("404.crowdin_link"),
+      crowdinCode: crowdinCode(locale),
+      crowdinLinkLabel: resolver("404.crowdin_link.label"),
+      crowdinLinkText: resolver("404.crowdin_link"),
 
-      englishLinkLabel: websiteResolver("404.english_link.label"),
-      englishLinkText: websiteResolver("404.english_link"),
+      englishLinkLabel: resolver("404.english_link.label"),
+      englishLinkText: resolver("404.english_link"),
 
-      linkLabel: websiteResolver("404.link.label"),
-      linkText: websiteResolver("404.link"),
+      linkLabel: resolver("404.link.label"),
+      linkText: resolver("404.link"),
     },
 
     outline: {
-      label: websiteResolver("outline"),
+      label: resolver("outline"),
       level: "deep",
     },
 
-    returnToTopLabel: websiteResolver("return_to_top"),
+    returnToTopLabel: resolver("return_to_top"),
 
     search: {
       provider: "local",
       options: {
         translations: {
           button: {
-            buttonAriaLabel: websiteResolver("search.button"),
-            buttonText: websiteResolver("search.button"),
+            buttonAriaLabel: resolver("search.button"),
+            buttonText: resolver("search.button"),
           },
           modal: {
-            backButtonTitle: websiteResolver("search.back"),
-            displayDetails: websiteResolver("search.display_details"),
-            noResultsText: websiteResolver("search.no_results"),
-            resetButtonTitle: websiteResolver("search.reset"),
+            backButtonTitle: resolver("search.back"),
+            displayDetails: resolver("search.display_details"),
+            noResultsText: resolver("search.no_results"),
+            resetButtonTitle: resolver("search.reset"),
             footer: {
-              closeKeyAriaLabel: websiteResolver("search.footer.close.key"),
-              closeText: websiteResolver("search.footer.close"),
-              navigateDownKeyAriaLabel: websiteResolver("search.footer.down.key"),
-              navigateText: websiteResolver("search.footer.navigate"),
-              navigateUpKeyAriaLabel: websiteResolver("search.footer.up.key"),
-              selectKeyAriaLabel: websiteResolver("search.footer.select.key"),
-              selectText: websiteResolver("search.footer.select"),
+              closeKeyAriaLabel: resolver("search.footer.close.key"),
+              closeText: resolver("search.footer.close"),
+              navigateDownKeyAriaLabel: resolver("search.footer.down.key"),
+              navigateText: resolver("search.footer.navigate"),
+              navigateUpKeyAriaLabel: resolver("search.footer.up.key"),
+              selectKeyAriaLabel: resolver("search.footer.select.key"),
+              selectText: resolver("search.footer.select"),
             },
           },
         },
       },
     },
 
-    sidebar: generateTranslatedSidebars(
-      {
-        "/players/": PlayersSidebar,
-        "/develop/": DevelopSidebar,
-      },
-      __dirname
-    ),
+    sidebar: translateSidebars({ "/players/": Players, "/develop/": Develop }),
 
-    sidebarMenuLabel: websiteResolver("sidebar_menu"),
+    sidebarMenuLabel: resolver("sidebar_menu"),
 
-    siteTitle: websiteResolver("title"),
+    siteTitle: resolver("title"),
 
     socialLinks: [
       {
         icon: "github",
         link: "https://github.com/FabricMC/fabric-docs",
-        ariaLabel: websiteResolver("social.github"),
+        ariaLabel: resolver("social.github"),
       },
       {
         icon: "discord",
         link: "https://discord.gg/v6v4pMv",
-        ariaLabel: websiteResolver("social.discord"),
+        ariaLabel: resolver("social.discord"),
       },
       {
         icon: "crowdin",
-        link: `https://crowdin.com/project/fabricmc/${crowdinCode(localeCode) ?? ""}`,
-        ariaLabel: websiteResolver("social.crowdin"),
+        link: `https://crowdin.com/project/fabricmc/${crowdinCode(locale) ?? ""}`,
+        ariaLabel: resolver("social.crowdin"),
       },
     ],
 
     version: {
-      reminder: websiteResolver("version.reminder"),
-      switcher: websiteResolver("version.switcher"),
+      reminder: resolver("version.reminder"),
+      switcher: resolver("version.switcher"),
     },
 
     versionSwitcher: false,
@@ -343,35 +325,34 @@ const generateTranslatedThemeConfig = (localeCode: string): Fabric.ThemeConfig =
 /**
  * Loads locales and generates a LocaleConfig object.
  *
- * @param dirname - The root directory of the project.
  * @returns A LocaleConfig object with locales and their corresponding themeConfig.
  */
-export const loadLocales = (dirname: string): LocaleConfig<Fabric.ThemeConfig> => {
-  const translatedFolder = resolve(dirname, "..", "translated");
+export const getLocales = (): LocaleConfig<Fabric.ThemeConfig> => {
+  const translatedFolder = resolve(__dirname, "..", "translated");
   const localeFolders = readdirSync(translatedFolder, { withFileTypes: true })
     .filter((dirent) => dirent.isDirectory())
     .map((dirent) => dirent.name);
 
-  const websiteResolver = getWebsiteResolver("root");
+  const resolver = getWebsiteResolver("root");
   const locales: LocaleConfig<Fabric.ThemeConfig> = {
     root: {
-      description: websiteResolver("description"),
+      description: resolver("description"),
       label: "🇬🇧 English",
       lang: "en",
-      themeConfig: generateTranslatedThemeConfig("root"),
-      title: websiteResolver("title"),
+      themeConfig: translateThemeConfig("root"),
+      title: resolver("title"),
     },
   };
 
-  for (const localeCode of localeFolders) {
-    const websiteResolver = getWebsiteResolver(localeCode);
+  for (const locale of localeFolders) {
+    const resolver = getWebsiteResolver(locale);
 
-    if (!existsSync(resolve(translatedFolder, localeCode, "index.md"))) {
+    if (!existsSync(resolve(translatedFolder, locale, "index.md"))) {
       continue;
     }
 
-    const language = localeCode.slice(0, 2);
-    const region = localeCode.slice(3, 5).toUpperCase();
+    const language = locale.slice(0, 2);
+    const region = locale.slice(3, 5).toUpperCase();
 
     const localeNameInLocale = new Intl.DisplayNames(language, {
       type: "language",
@@ -395,13 +376,13 @@ export const loadLocales = (dirname: string): LocaleConfig<Fabric.ThemeConfig> =
       ...region.split("").map((char) => 127397 + char.charCodeAt(0))
     );
 
-    locales[localeCode] = {
-      description: websiteResolver("description"),
+    locales[locale] = {
+      description: resolver("description"),
       label: `${countryFlag} ${localizedName} (${englishName})`,
-      lang: localeCode,
-      link: `/${localeCode}/`,
-      themeConfig: generateTranslatedThemeConfig(localeCode),
-      title: websiteResolver("title"),
+      lang: locale,
+      link: `/${locale}/`,
+      themeConfig: translateThemeConfig(locale),
+      title: resolver("title"),
     };
   }
 

--- a/.vitepress/i18n.ts
+++ b/.vitepress/i18n.ts
@@ -7,10 +7,7 @@ import DevelopSidebar from "./sidebars/develop";
 import PlayersSidebar from "./sidebars/players";
 import { Fabric } from "./types";
 
-function getTranslationsResolver(
-  localeFolder: string,
-  fileName: string
-): (key: string) => string {
+function getTranslationsResolver(localeFolder: string, fileName: string): (key: string) => string {
   const file = resolve(
     __dirname,
     "..",
@@ -26,8 +23,7 @@ function getTranslationsResolver(
   if (localeFolder === "root") {
     return (key: string) => strings[key] || key;
   } else {
-    return (key: string) =>
-      strings[key] || getTranslationsResolver("root", fileName)(key);
+    return (key: string) => strings[key] || getTranslationsResolver("root", fileName)(key);
   }
 }
 export const getWebsiteResolver = (localeFolder: string) =>
@@ -35,9 +31,7 @@ export const getWebsiteResolver = (localeFolder: string) =>
 export const getSidebarResolver = (localeFolder: string) =>
   getTranslationsResolver(localeFolder, "sidebar_translations.json");
 
-export function processExistingEntries(
-  sidebar: Versioned.Sidebar
-): Versioned.Sidebar {
+export function processExistingEntries(sidebar: Versioned.Sidebar): Versioned.Sidebar {
   // Get locales from __dirname/../translated/* folder names.
   const localeFolders = readdirSync(resolve(__dirname, "..", "translated"), {
     withFileTypes: true,
@@ -51,9 +45,9 @@ export function processExistingEntries(
   const keys = Object.keys(sidebar);
   const versionedEntries = keys.filter((key) => {
     return (
-      !key.includes("/players") &&
-      !key.includes("/develop") &&
-      localeFolders.some((locale) => key.includes(locale))
+      !key.includes("/players")
+      && !key.includes("/develop")
+      && localeFolders.some((locale) => key.includes(locale))
     );
   });
 
@@ -66,21 +60,11 @@ export function processExistingEntries(
 
     versionsMet.add(version);
 
-    const playersToCopy = JSON.parse(
-      JSON.stringify(sidebar[`/${version}/players/`])
-    );
-    const developToCopy = JSON.parse(
-      JSON.stringify(sidebar[`/${version}/develop/`])
-    );
+    const playersToCopy = JSON.parse(JSON.stringify(sidebar[`/${version}/players/`]));
+    const developToCopy = JSON.parse(JSON.stringify(sidebar[`/${version}/develop/`]));
 
-    sidebar[`/${locale}/${version}/players/`] = getLocalizedSidebar(
-      playersToCopy,
-      locale
-    );
-    sidebar[`/${locale}/${version}/develop/`] = getLocalizedSidebar(
-      developToCopy,
-      locale
-    );
+    sidebar[`/${locale}/${version}/players/`] = getLocalizedSidebar(playersToCopy, locale);
+    sidebar[`/${locale}/${version}/develop/`] = getLocalizedSidebar(developToCopy, locale);
 
     // Delete the original entry.
     delete sidebar[entry];
@@ -151,10 +135,7 @@ export function generateTranslatedSidebars(
     .map((dirent) => dirent.name)) {
     for (const key of Object.keys(sidebars)) {
       const sidebar = sidebars[key];
-      translatedSidebars["/" + folder + key] = getLocalizedSidebar(
-        sidebar,
-        folder
-      );
+      translatedSidebars["/" + folder + key] = getLocalizedSidebar(sidebar, folder);
     }
   }
 
@@ -173,7 +154,7 @@ function generateTranslatedThemeConfig(localeCode: string): Fabric.ThemeConfig {
   const crowdinCode = (localeCode: string): string | null => {
     // https://developer.crowdin.com/language-codes
     // TODO: this is hardcoded
-    const crowdinOverrides = {
+    const crowdinOverrides: Record<string, string> = {
       es_es: "es-ES",
       pt_br: "pt-BR",
       zh_cn: "zh-CN",
@@ -252,8 +233,7 @@ function generateTranslatedThemeConfig(localeCode: string): Fabric.ThemeConfig {
           // TODO: Expand on this later, with guidelines for loader+loom potentially?
           {
             text: websiteResolver("title"),
-            link:
-              (localeCode === "root" ? "" : `/${localeCode}`) + "/contributing",
+            link: (localeCode === "root" ? "" : `/${localeCode}`) + "/contributing",
           },
           {
             text: websiteResolver("nav.contribute.api"),
@@ -305,9 +285,7 @@ function generateTranslatedThemeConfig(localeCode: string): Fabric.ThemeConfig {
             footer: {
               closeKeyAriaLabel: websiteResolver("search.footer.close.key"),
               closeText: websiteResolver("search.footer.close"),
-              navigateDownKeyAriaLabel: websiteResolver(
-                "search.footer.down.key"
-              ),
+              navigateDownKeyAriaLabel: websiteResolver("search.footer.down.key"),
               navigateText: websiteResolver("search.footer.navigate"),
               navigateUpKeyAriaLabel: websiteResolver("search.footer.up.key"),
               selectKeyAriaLabel: websiteResolver("search.footer.select.key"),
@@ -343,9 +321,7 @@ function generateTranslatedThemeConfig(localeCode: string): Fabric.ThemeConfig {
       },
       {
         icon: "crowdin",
-        link: `https://crowdin.com/project/fabricmc/${
-          crowdinCode(localeCode) ?? ""
-        }`,
+        link: `https://crowdin.com/project/fabricmc/${crowdinCode(localeCode) ?? ""}`,
         ariaLabel: websiteResolver("social.crowdin"),
       },
     ],
@@ -405,13 +381,10 @@ export function loadLocales(dirname: string): LocaleConfig<Fabric.ThemeConfig> {
     const englishName =
       language === region.toLowerCase()
         ? localeNameInEnglish.of(language)!
-        : localeNameInEnglish.of(language)! +
-          " - " +
-          regionNameInEnglish.of(region);
+        : localeNameInEnglish.of(language)! + " - " + regionNameInEnglish.of(region);
 
     const localizedName =
-      localeNameInLocale.of(language)![0].toUpperCase() +
-      localeNameInLocale.of(language)!.slice(1);
+      localeNameInLocale.of(language)![0].toUpperCase() + localeNameInLocale.of(language)!.slice(1);
 
     const countryFlag = String.fromCodePoint(
       ...region.split("").map((char) => 127397 + char.charCodeAt(0))

--- a/.vitepress/i18n.ts
+++ b/.vitepress/i18n.ts
@@ -128,7 +128,7 @@ const translateSidebars = (
     .map((dirent) => dirent.name)) {
     for (const key of Object.keys(sidebars)) {
       const sidebar = sidebars[key];
-      translatedSidebars["/" + folder + key] = getLocalizedSidebar(sidebar, folder);
+      translatedSidebars[`/${folder}${key}`] = getLocalizedSidebar(sidebar, folder);
     }
   }
 
@@ -226,7 +226,7 @@ const translateThemeConfig = (locale: string): Fabric.ThemeConfig => {
           // TODO: Expand on this later, with guidelines for loader+loom potentially?
           {
             text: resolver("title"),
-            link: (locale === "root" ? "" : `/${locale}`) + "/contributing",
+            link: `${locale === "root" ? "" : `/${locale}`}/contributing`,
           },
           {
             text: resolver("nav.contribute.api"),
@@ -367,10 +367,11 @@ export const getLocales = (): LocaleConfig<Fabric.ThemeConfig> => {
     const englishName =
       language === region.toLowerCase()
         ? localeNameInEnglish.of(language)!
-        : localeNameInEnglish.of(language)! + " - " + regionNameInEnglish.of(region);
+        : `${localeNameInEnglish.of(language)!} - ${regionNameInEnglish.of(region)}`;
 
-    const localizedName =
-      localeNameInLocale.of(language)![0].toUpperCase() + localeNameInLocale.of(language)!.slice(1);
+    const localizedName = `${localeNameInLocale.of(language)![0].toUpperCase()}${localeNameInLocale
+      .of(language)!
+      .slice(1)}`;
 
     const countryFlag = String.fromCodePoint(
       ...region.split("").map((char) => 127397 + char.charCodeAt(0))

--- a/.vitepress/theme/components/AuthorsComponent.vue
+++ b/.vitepress/theme/components/AuthorsComponent.vue
@@ -21,7 +21,10 @@ const combinedAuthors = computed<{ name: string; noGitHub?: true }[]>(() => {
   <div v-if="combinedAuthors.length" class="authors-section">
     <h2>{{ heading }}</h2>
     <div class="page-authors">
-      <template v-for="author in combinedAuthors" :key="(author.noGitHub ? ':' : '') + author.name">
+      <template
+        v-for="author in combinedAuthors"
+        :key="`${author.noGitHub ? ':' : ''}${author.name}`"
+      >
         <img
           v-if="author.noGitHub"
           loading="lazy"

--- a/.vitepress/theme/components/AuthorsComponent.vue
+++ b/.vitepress/theme/components/AuthorsComponent.vue
@@ -8,18 +8,12 @@ const labelNoGitHub = computed(() => data.theme.value.authors.noGitHub);
 
 const combinedAuthors = computed<{ name: string; noGitHub?: true }[]>(() => {
   const authors: string[] = data.frontmatter.value["authors"] || [];
-  const authorsNoGitHub: string[] =
-    data.frontmatter.value["authors-nogithub"] || [];
+  const authorsNoGitHub: string[] = data.frontmatter.value["authors-nogithub"] || [];
 
   const withGitHub = authors.map((name) => ({ name }));
-  const withoutGitHub = authorsNoGitHub.map((name) => ({
-    name,
-    noGitHub: true,
-  }));
+  const withoutGitHub = authorsNoGitHub.map((name) => ({ name, noGitHub: true }));
 
-  return [...withGitHub, ...withoutGitHub].sort((a, b) =>
-    a.name.localeCompare(b.name)
-  );
+  return [...withGitHub, ...withoutGitHub].sort((a, b) => a.name.localeCompare(b.name));
 });
 </script>
 
@@ -27,10 +21,7 @@ const combinedAuthors = computed<{ name: string; noGitHub?: true }[]>(() => {
   <div v-if="combinedAuthors.length" class="authors-section">
     <h2>{{ heading }}</h2>
     <div class="page-authors">
-      <template
-        v-for="author in combinedAuthors"
-        :key="(author.noGitHub ? ':' : '') + author.name"
-      >
+      <template v-for="author in combinedAuthors" :key="(author.noGitHub ? ':' : '') + author.name">
         <img
           v-if="author.noGitHub"
           loading="lazy"

--- a/.vitepress/theme/components/BannerComponent.vue
+++ b/.vitepress/theme/components/BannerComponent.vue
@@ -20,10 +20,7 @@ const text = computed(() => {
 
 watchEffect(() => {
   if (height.value) {
-    document.documentElement.style.setProperty(
-      "--vp-layout-top-height",
-      `${height.value}px`
-    );
+    document.documentElement.style.setProperty("--vp-layout-top-height", `${height.value}px`);
   }
 });
 </script>
@@ -39,11 +36,9 @@ watchEffect(() => {
         >{{ options.github }}</a
       >
       {{ text[1] }}
-      <a
-        href="https://discord.gg/v6v4pMv"
-        target="_blank"
-        rel="noopener noreferrer"
-        >{{ options.discord }}</a
+      <a href="https://discord.gg/v6v4pMv" target="_blank" rel="noopener noreferrer">{{
+        options.discord
+      }}</a
       >{{ text[2] }}
     </div>
   </div>

--- a/.vitepress/theme/components/DownloadEntry.vue
+++ b/.vitepress/theme/components/DownloadEntry.vue
@@ -27,14 +27,7 @@ const text = computed(() => {
       :src="props.visualURL ?? props.downloadURL"
       style="max-width: 100%; max-height: 300px"
     />
-    <VPButton
-      tag="a"
-      size="medium"
-      theme="brand"
-      :text="text"
-      :href="props.downloadURL"
-      download
-    />
+    <VPButton tag="a" size="medium" theme="brand" :text="text" :href="props.downloadURL" download />
   </div>
 </template>
 

--- a/.vitepress/theme/components/NotFoundComponent.vue
+++ b/.vitepress/theme/components/NotFoundComponent.vue
@@ -7,9 +7,7 @@ import { Fabric } from "../../types";
 const data = useData();
 const route = useRoute();
 
-const options = computed(
-  () => data.theme.value.notFound as Fabric.NotFoundOptions
-);
+const options = computed(() => data.theme.value.notFound as Fabric.NotFoundOptions);
 
 const urls = computed(() => {
   const locale = data.localeIndex.value;
@@ -21,13 +19,9 @@ const urls = computed(() => {
   } else {
     urls["home"] = `/${locale}/`;
     // TODO: hide if English=404
-    urls["english"] = (route.path.split("//")[1] ?? route.path).replace(
-      urls["home"],
-      "/"
-    );
+    urls["english"] = (route.path.split("//")[1] ?? route.path).replace(urls["home"], "/");
     // TODO: link to file: https://developer.crowdin.com/api/v2/#operation/api.projects.files.getMany
-    urls["crowdin"] =
-      "https://crowdin.com/project/fabricmc/" + options.value.crowdinCode;
+    urls["crowdin"] = "https://crowdin.com/project/fabricmc/" + options.value.crowdinCode;
   }
   return urls;
 });
@@ -120,7 +114,9 @@ const urls = computed(() => {
   font-size: 14px;
   font-weight: 500;
   color: var(--vp-c-brand-1);
-  transition: border-color 0.25s, color 0.25s;
+  transition:
+    border-color 0.25s,
+    color 0.25s;
 }
 
 .link:hover {

--- a/.vitepress/theme/components/NotFoundComponent.vue
+++ b/.vitepress/theme/components/NotFoundComponent.vue
@@ -21,7 +21,7 @@ const urls = computed(() => {
     // TODO: hide if English=404
     urls["english"] = (route.path.split("//")[1] ?? route.path).replace(urls["home"], "/");
     // TODO: link to file: https://developer.crowdin.com/api/v2/#operation/api.projects.files.getMany
-    urls["crowdin"] = "https://crowdin.com/project/fabricmc/" + options.value.crowdinCode;
+    urls["crowdin"] = `https://crowdin.com/project/fabricmc/${options.value.crowdinCode}`;
   }
   return urls;
 });

--- a/.vitepress/theme/components/VersionSwitcher.vue
+++ b/.vitepress/theme/components/VersionSwitcher.vue
@@ -20,14 +20,14 @@ const currentVersion = ref<string>(props.versioningPlugin.latestVersion);
 const isOpen = ref(false);
 
 // Helper function to find the matching version from the current route path
-function getVersionFromPath(path: string): string {
+const getVersionFromPath = (path: string): string => {
   for (const v of props.versioningPlugin.versions) {
     if (path.includes(`/${v}/`)) {
       return v;
     }
   }
   return props.versioningPlugin.latestVersion;
-}
+};
 
 // Before route change, update the current version
 router.onBeforeRouteChange = (to: string) => {
@@ -50,7 +50,7 @@ const toggle = () => {
 };
 
 // Constructs the appropriate route path for a given version
-function buildRoutePath(currentPath: string, locale: string | null, newV: string) {
+const buildRoutePath = (currentPath: string, locale: string | null, newV: string) => {
   const currentV = currentVersion.value;
   const latestV = props.versioningPlugin.latestVersion;
   const pathParts = currentPath.split("/").filter(Boolean);
@@ -69,10 +69,10 @@ function buildRoutePath(currentPath: string, locale: string | null, newV: string
   }
 
   return "/" + pathParts.join("/") + "/";
-}
+};
 
 // Navigate to the selected version
-function visitVersion(version: string) {
+const visitVersion = (version: string) => {
   const localeKeys = Object.keys(data.site.value.locales);
   const isLocalized = localeKeys.some((key) => router.route.path.startsWith(`/${key}/`));
   const locale = isLocalized
@@ -83,7 +83,7 @@ function visitVersion(version: string) {
 
   router.go(route);
   currentVersion.value = version;
-}
+};
 </script>
 
 <template>

--- a/.vitepress/theme/components/VersionSwitcher.vue
+++ b/.vitepress/theme/components/VersionSwitcher.vue
@@ -50,11 +50,7 @@ const toggle = () => {
 };
 
 // Constructs the appropriate route path for a given version
-function buildRoutePath(
-  currentPath: string,
-  locale: string | null,
-  newV: string
-) {
+function buildRoutePath(currentPath: string, locale: string | null, newV: string) {
   const currentV = currentVersion.value;
   const latestV = props.versioningPlugin.latestVersion;
   const pathParts = currentPath.split("/").filter(Boolean);
@@ -78,9 +74,7 @@ function buildRoutePath(
 // Navigate to the selected version
 function visitVersion(version: string) {
   const localeKeys = Object.keys(data.site.value.locales);
-  const isLocalized = localeKeys.some((key) =>
-    router.route.path.startsWith(`/${key}/`)
-  );
+  const isLocalized = localeKeys.some((key) => router.route.path.startsWith(`/${key}/`));
   const locale = isLocalized
     ? localeKeys.find((key) => router.route.path.startsWith(`/${key}/`)) || null
     : null;
@@ -112,12 +106,7 @@ function visitVersion(version: string) {
       </VPLink>
       <!-- Render links for each version -->
       <template v-for="version in versioningPlugin.versions" :key="version">
-        <VPLink
-          href="#"
-          :tag="'a'"
-          v-if="currentVersion != version"
-          @click="visitVersion(version)"
-        >
+        <VPLink href="#" :tag="'a'" v-if="currentVersion != version" @click="visitVersion(version)">
           {{ version }}
         </VPLink>
       </template>
@@ -132,9 +121,7 @@ function visitVersion(version: string) {
       :aria-expanded="isOpen"
       @click="toggle"
     >
-      <span class="button-text">
-        <span class="vpi-versioning icon" />{{ text }}
-      </span>
+      <span class="button-text"> <span class="vpi-versioning icon" />{{ text }} </span>
       <span class="vpi-plus button-icon" />
     </button>
 
@@ -165,7 +152,9 @@ function visitVersion(version: string) {
   font-weight: 500;
   color: var(--vp-c-text-1);
   white-space: nowrap;
-  transition: background-color 0.25s, color 0.25s;
+  transition:
+    background-color 0.25s,
+    color 0.25s;
 }
 .link:hover {
   color: var(--vp-c-brand-1);

--- a/.vitepress/theme/components/VersionSwitcher.vue
+++ b/.vitepress/theme/components/VersionSwitcher.vue
@@ -68,7 +68,7 @@ const buildRoutePath = (currentPath: string, locale: string | null, newV: string
     pathParts.splice(versionIndex, 0, newV);
   }
 
-  return "/" + pathParts.join("/") + "/";
+  return `/${pathParts.join("/")}/`;
 };
 
 // Navigate to the selected version

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -16,7 +16,7 @@ import "./style.css";
 
 export default {
   extends: DefaultTheme,
-  enhanceApp({ app }) {
+  enhanceApp: ({ app }) => {
     // VidStack VideoPlayer Component
     app.config.compilerOptions.isCustomElement = (tag) => tag.startsWith("media-");
 
@@ -29,7 +29,7 @@ export default {
     // Versioning Plugin Components
     app.component("VersionSwitcher", VersionSwitcher);
   },
-  Layout() {
+  Layout: () => {
     const { page, frontmatter } = useData();
 
     const children = {
@@ -48,7 +48,7 @@ export default {
 
     return h(DefaultTheme.Layout, null, children);
   },
-  setup() {
+  setup: () => {
     const route = useRoute();
     const initZoom = () => {
       mediumZoom(".main img", { background: "var(--vp-c-bg)" });

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -18,8 +18,7 @@ export default {
   extends: DefaultTheme,
   enhanceApp({ app }) {
     // VidStack VideoPlayer Component
-    app.config.compilerOptions.isCustomElement = (tag) =>
-      tag.startsWith("media-");
+    app.config.compilerOptions.isCustomElement = (tag) => tag.startsWith("media-");
 
     // Custom Components for Pages
     app.component("ChoiceComponent", ChoiceComponent);
@@ -35,9 +34,7 @@ export default {
 
     const children = {
       "doc-before": () => [
-        frontmatter.value.title
-          ? h("h1", { class: "vp-doc" }, frontmatter.value.title)
-          : null,
+        frontmatter.value.title ? h("h1", { class: "vp-doc" }, frontmatter.value.title) : null,
         h(VersionReminder),
         h(AuthorsComponent),
       ],
@@ -46,7 +43,7 @@ export default {
     };
 
     if (page.value.isNotFound) {
-      children["not-found"] = () => h(NotFoundComponent);
+      (children as any)["not-found"] = () => h(NotFoundComponent);
     }
 
     return h(DefaultTheme.Layout, null, children);

--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -6,8 +6,9 @@
 /* Emoji Flag Unicode Polyfill */
 @font-face {
   font-family: "Flag Emoji Polyfill";
-  unicode-range: U+1F1E6-1F1FF, U+1F3F4, U+E0062-E0063, U+E0065, U+E0067,
-    U+E006C, U+E006E, U+E0073-E0074, U+E0077, U+E007F;
+  unicode-range:
+    U+1F1E6-1F1FF, U+1F3F4, U+E0062-E0063, U+E0065, U+E0067, U+E006C, U+E006E, U+E0073-E0074,
+    U+E0077, U+E007F;
   src: url("./CountryFlagsPolyfill.woff2") format("woff2");
   font-display: swap;
 }
@@ -26,23 +27,19 @@
 
   /* Override Hero Text Gradient */
   --vp-home-hero-name-color: transparent;
-  --vp-home-hero-name-background: -webkit-linear-gradient(
-    120deg,
-    #3463fe 30%,
-    #4787ff
-  );
+  --vp-home-hero-name-background: -webkit-linear-gradient(120deg, #3463fe 30%, #4787ff);
 
   /* Flag Emoji Polyfill (Chrome does not render county flags on windows) */
-  --vp-font-family-base: "Flag Emoji Polyfill", "Inter", ui-sans-serif,
-    system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-    "Segoe UI Symbol", "Noto Color Emoji";
+  --vp-font-family-base:
+    "Flag Emoji Polyfill", "Inter", ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji",
+    "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 }
 
 :root:where(:lang(zh)) {
   /* Flag Emoji Polyfill (Chrome does not render county flags on windows) */
-  --vp-font-family-base: "Flag Emoji Polyfill", "Punctuation SC", "Inter",
-    ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-    "Segoe UI Symbol", "Noto Color Emoji";
+  --vp-font-family-base:
+    "Flag Emoji Polyfill", "Punctuation SC", "Inter", ui-sans-serif, system-ui, sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 }
 
 /* Sidebar Scrollbar - Styles scrollbars within the side navigation pane for improved visibility. */

--- a/.vitepress/transform.ts
+++ b/.vitepress/transform.ts
@@ -11,7 +11,7 @@ export const transformPageData = (pageData: PageData) => {
   const parts = pageData.relativePath.split("/");
   const websiteTitle = getWebsiteResolver(parts[0][2] === "_" ? parts[0] : "root")("title");
   const title =
-    pageData.frontmatter.layout === "home" ? websiteTitle : pageData.title + " | " + websiteTitle;
+    pageData.frontmatter.layout === "home" ? websiteTitle : `${pageData.title} | ${websiteTitle}`;
 
   const tags = [
     ["theme-color", "#2275da"],
@@ -53,7 +53,7 @@ export const transformItems = (items: any[]): any[] => {
 
   const itemsCopy = [...items];
   for (const item of items) {
-    const path = item.url.replace("https://docs.fabricmc.net/", "") + ".md";
+    const path = `${item.url.replace("https://docs.fabricmc.net/", "")}.md`;
 
     // Remove the item if it's a versioned item
     if (inverseRewrites[path]?.includes("versions")) {

--- a/.vitepress/transform.ts
+++ b/.vitepress/transform.ts
@@ -3,9 +3,9 @@ import { PageData, SiteConfig } from "vitepress";
 import { getWebsiteResolver } from "./i18n";
 
 /**
- * Adds open graph data (social media embed info) and tells web crawlers to not index versioned pages.
+ * Add open graph data (social media embed info) and tell web crawlers to not index versioned pages.
  */
-export function transformPageData(pageData: PageData, _context: any) {
+export const transformPageData = (pageData: PageData) => {
   pageData.frontmatter.head ??= [];
 
   const parts = pageData.relativePath.split("/");
@@ -45,9 +45,9 @@ export function transformPageData(pageData: PageData, _context: any) {
       },
     ]);
   }
-}
+};
 
-export function transformItems(items: any[]): any[] {
+export const transformItems = (items: any[]): any[] => {
   const config = (globalThis as any).VITEPRESS_CONFIG as SiteConfig;
   const inverseRewrites = config.rewrites.inv;
 
@@ -62,4 +62,4 @@ export function transformItems(items: any[]): any[] {
   }
 
   return itemsCopy;
-}
+};

--- a/.vitepress/transform.ts
+++ b/.vitepress/transform.ts
@@ -9,13 +9,9 @@ export function transformPageData(pageData: PageData, _context: any) {
   pageData.frontmatter.head ??= [];
 
   const parts = pageData.relativePath.split("/");
-  const websiteTitle = getWebsiteResolver(
-    parts[0][2] === "_" ? parts[0] : "root"
-  )("title");
+  const websiteTitle = getWebsiteResolver(parts[0][2] === "_" ? parts[0] : "root")("title");
   const title =
-    pageData.frontmatter.layout === "home"
-      ? websiteTitle
-      : pageData.title + " | " + websiteTitle;
+    pageData.frontmatter.layout === "home" ? websiteTitle : pageData.title + " | " + websiteTitle;
 
   const tags = [
     ["theme-color", "#2275da"],
@@ -52,7 +48,7 @@ export function transformPageData(pageData: PageData, _context: any) {
 }
 
 export function transformItems(items: any[]): any[] {
-  const config = globalThis.VITEPRESS_CONFIG as SiteConfig;
+  const config = (globalThis as any).VITEPRESS_CONFIG as SiteConfig;
   const inverseRewrites = config.rewrites.inv;
 
   const itemsCopy = [...items];

--- a/.vitepress/types.ts
+++ b/.vitepress/types.ts
@@ -34,14 +34,14 @@ export namespace Fabric {
     /**
      * Set custom text for download button.
      *
-     * @default 'Download %s'
+     * @default "Download %s"
      */
     text: string;
   }
 
   export interface NotFoundOptions {
     /**
-     * @default '404'
+     * @default "404"
      */
     code: string;
 
@@ -102,7 +102,7 @@ export namespace Fabric {
     /**
      * Set custom not found message.
      *
-     * @default 'Page not found'
+     * @default "Page not found"
      */
     title: string;
   }
@@ -125,14 +125,14 @@ export namespace Fabric {
     /**
      * Set custom text for switcher button.
      *
-     * @default 'Switch Version'
+     * @default "Switch Version"
      */
     switcher: string;
 
     /**
      * Set custom message for version reminder.
      *
-     * @default 'This page is written for version:'
+     * @default "This page is written for version:"
      */
     reminder: string;
   }

--- a/.vitepress/update.ts
+++ b/.vitepress/update.ts
@@ -26,7 +26,7 @@ import players from "./sidebars/players";
   if (!newVersion) process.exit(1);
   console.log(`New version: 'Minecraft ${newVersion}'`);
 
-  console.log("Fetching Yarn version for Minecraft " + newVersion + "...");
+  console.log(`Fetching Yarn version for Minecraft ${newVersion}...`);
   const yarnVersions: any[] = (await (
     await fetch(`https://meta.fabricmc.net/v2/versions/yarn/${newVersion}`)
   ).json()) as any[];
@@ -36,12 +36,12 @@ import players from "./sidebars/players";
     yarnVersion = yarnVersions[0]?.version;
   }
   if (!yarnVersion) {
-    console.error("No stable Yarn version found for Minecraft " + newVersion);
+    console.error(`No stable Yarn version found for Minecraft ${newVersion}`);
     process.exit(1);
   }
-  console.log("Found Yarn version " + yarnVersion);
+  console.log(`Found Yarn version ${yarnVersion}`);
 
-  console.log("Fetching Fabric API version for Minecraft " + newVersion + "...");
+  console.log(`Fetching Fabric API version for Minecraft ${newVersion}...`);
   const fabricApiVersions: any[] = (await (
     await fetch(
       `https://api.modrinth.com/v2/project/fabric-api/version?loaders=["fabric"]&game_versions=["${newVersion}"]&featured=true`
@@ -49,15 +49,15 @@ import players from "./sidebars/players";
   ).json()) as any[];
   const fabricApiVersion = fabricApiVersions[0]?.version_number;
   if (!fabricApiVersion) {
-    console.error("No Fabric API version found for Minecraft " + newVersion);
+    console.error(`No Fabric API version found for Minecraft ${newVersion}`);
     process.exit(1);
   }
-  console.log("Found Fabric API version " + fabricApiVersion);
+  console.log(`Found Fabric API version ${fabricApiVersion}`);
 
-  console.log("Copying latest -> " + oldVersion + "...");
+  console.log(`Copying latest -> ${oldVersion}...`);
 
   // Copy ./reference/latest/** -> ./reference/oldVersion/**
-  fs.cpSync("./reference/latest", "./reference/" + oldVersion, {
+  fs.cpSync("./reference/latest", `./reference/${oldVersion}`, {
     recursive: true,
   });
 
@@ -73,7 +73,7 @@ import players from "./sidebars/players";
   fs.writeFileSync("./reference/latest/build.gradle", newBuildGradle);
 
   console.log("Example mod has been bumped successfully.");
-  console.log("Migrating content to versioned/" + oldVersion + "...");
+  console.log(`Migrating content to versioned/${oldVersion}...`);
 
   // Move all markdown files except README.md to versions/oldVersion
   const markdownFiles = tinyglobby.globSync("**/*.md", {
@@ -82,8 +82,8 @@ import players from "./sidebars/players";
 
   // Copy into versions/oldVersion and respect the directory structure.
   for (const file of markdownFiles) {
-    const oldPath = "./" + file;
-    const newPath = "./versions/" + oldVersion + "/" + file;
+    const oldPath = `./${file}`;
+    const newPath = `./versions/${oldVersion}/${file}`;
     fs.cpSync(oldPath, newPath);
   }
 
@@ -96,7 +96,7 @@ import players from "./sidebars/players";
   };
 
   fs.writeFileSync(
-    "./.vitepress/sidebars/versioned/" + oldVersion + ".json",
+    `./.vitepress/sidebars/versioned/${oldVersion}.json`,
     JSON.stringify(versionedSidebar, null, 2)
   );
 

--- a/.vitepress/update.ts
+++ b/.vitepress/update.ts
@@ -6,145 +6,143 @@ import * as tinyglobby from "tinyglobby";
 import develop from "./sidebars/develop";
 import players from "./sidebars/players";
 
-(async () => {
-  // Determine old minecraft version by reading /reference/latest/build.gradle's `def minecraftVersion = "XXXX"` line.
-  const buildGradle = fs.readFileSync("./reference/latest/build.gradle", "utf-8");
-  const oldVersion = buildGradle.match(/def minecraftVersion = "([^"]+)"/)![1];
+// Determine old minecraft version by reading /reference/latest/build.gradle's `def minecraftVersion = "XXXX"` line.
+const buildGradle = fs.readFileSync("./reference/latest/build.gradle", "utf-8");
+const oldVersion = buildGradle.match(/def minecraftVersion = "([^"]+)"/)![1];
 
-  const newVersion: string = (
-    await prompts({
-      type: "text",
-      name: "version",
-      message: "Enter the new Minecraft version",
-      validate: (newVersion) => {
-        if (newVersion === oldVersion) return `Already on Minecraft ${newVersion}!`;
-        if (!/^[0-9.]+$/.test(newVersion)) return "Version must match /^[0-9.]+$/";
-        return true;
-      },
-    })
-  ).version;
-  if (!newVersion) process.exit(1);
-  console.log(`New version: 'Minecraft ${newVersion}'`);
+const newVersion: string = (
+  await prompts({
+    type: "text",
+    name: "version",
+    message: "Enter the new Minecraft version",
+    validate: (newVersion) => {
+      if (newVersion === oldVersion) return `Already on Minecraft ${newVersion}!`;
+      if (!/^[0-9.]+$/.test(newVersion)) return "Version must match /^[0-9.]+$/";
+      return true;
+    },
+  })
+).version;
+if (!newVersion) process.exit(1);
+console.log(`New version: 'Minecraft ${newVersion}'`);
 
-  console.log(`Fetching Yarn version for Minecraft ${newVersion}...`);
-  const yarnVersions: any[] = (await (
-    await fetch(`https://meta.fabricmc.net/v2/versions/yarn/${newVersion}`)
-  ).json()) as any[];
-  let yarnVersion: string = yarnVersions.find((v) => v.stable)?.version;
-  // Use latest version if no stable version is found.
-  if (!yarnVersion) {
-    yarnVersion = yarnVersions[0]?.version;
-  }
-  if (!yarnVersion) {
-    console.error(`No stable Yarn version found for Minecraft ${newVersion}`);
-    process.exit(1);
-  }
-  console.log(`Found Yarn version ${yarnVersion}`);
+console.log(`Fetching Yarn version for Minecraft ${newVersion}...`);
+const yarnVersions: any[] = (await (
+  await fetch(`https://meta.fabricmc.net/v2/versions/yarn/${newVersion}`)
+).json()) as any[];
+let yarnVersion: string = yarnVersions.find((v) => v.stable)?.version;
+// Use latest version if no stable version is found.
+if (!yarnVersion) {
+  yarnVersion = yarnVersions[0]?.version;
+}
+if (!yarnVersion) {
+  console.error(`No stable Yarn version found for Minecraft ${newVersion}`);
+  process.exit(1);
+}
+console.log(`Found Yarn version ${yarnVersion}`);
 
-  console.log(`Fetching Fabric API version for Minecraft ${newVersion}...`);
-  const fabricApiVersions: any[] = (await (
-    await fetch(
-      `https://api.modrinth.com/v2/project/fabric-api/version?loaders=["fabric"]&game_versions=["${newVersion}"]&featured=true`
+console.log(`Fetching Fabric API version for Minecraft ${newVersion}...`);
+const fabricApiVersions: any[] = (await (
+  await fetch(
+    `https://api.modrinth.com/v2/project/fabric-api/version?loaders=["fabric"]&game_versions=["${newVersion}"]&featured=true`
+  )
+).json()) as any[];
+const fabricApiVersion = fabricApiVersions[0]?.version_number;
+if (!fabricApiVersion) {
+  console.error(`No Fabric API version found for Minecraft ${newVersion}`);
+  process.exit(1);
+}
+console.log(`Found Fabric API version ${fabricApiVersion}`);
+
+console.log(`Copying latest -> ${oldVersion}...`);
+
+// Copy ./reference/latest/** -> ./reference/oldVersion/**
+fs.cpSync("./reference/latest", `./reference/${oldVersion}`, {
+  recursive: true,
+});
+
+// Update build.gradle in latest with new versions.
+// def minecraftVersion = "XXX"
+// def yarnVersion = "XXXXX"
+// def fabricApiVersion = "XXXX"
+const newBuildGradle = buildGradle
+  .replace(/def minecraftVersion = "([^"]+)"/, `def minecraftVersion = "${newVersion}"`)
+  .replace(/def yarnVersion = "([^"]+)"/, `def yarnVersion = "${yarnVersion}"`)
+  .replace(/def fabricApiVersion = "([^"]+)"/, `def fabricApiVersion = "${fabricApiVersion}"`);
+
+fs.writeFileSync("./reference/latest/build.gradle", newBuildGradle);
+
+console.log("Example mod has been bumped successfully.");
+console.log(`Migrating content to versioned/${oldVersion}...`);
+
+// Move all markdown files except README.md to versions/oldVersion
+const markdownFiles = tinyglobby.globSync("**/*.md", {
+  ignore: ["README.md", "contributing.md", "versions/**/*.md", "node_modules/**/*"],
+});
+
+// Copy into versions/oldVersion and respect the directory structure.
+for (const file of markdownFiles) {
+  const oldPath = `./${file}`;
+  const newPath = `./versions/${oldVersion}/${file}`;
+  fs.cpSync(oldPath, newPath);
+}
+
+console.log("Migration complete.");
+console.log("Migration sidebars...");
+
+const versionedSidebar = {
+  "/players/": players,
+  "/develop/": develop,
+};
+
+fs.writeFileSync(
+  `./.vitepress/sidebars/versioned/${oldVersion}.json`,
+  JSON.stringify(versionedSidebar, null, 2)
+);
+
+console.log("Migrated sidebars.");
+
+console.log("Updating internal links...");
+
+// Get all markdown files within versions/oldVersion
+const versionedMarkdownFiles = tinyglobby.globSync(`versions/${oldVersion}/**/*.md`);
+// Process all content
+for (const file of versionedMarkdownFiles) {
+  const content = fs.readFileSync(file, "utf-8");
+
+  // Replace all instances of /reference/latest with /reference/oldVersion
+  const newContent = content.replace(/\/reference\/latest/g, `/reference/${oldVersion}`);
+  fs.writeFileSync(file, newContent);
+}
+
+console.log("Updated internal links.");
+
+console.log("Adding warning box to index.md...");
+fs.writeFileSync(
+  `./versions/${oldVersion}/index.md`,
+  fs
+    .readFileSync(`./versions/${oldVersion}/index.md`, "utf-8")
+    .replace(
+      /^---\n\n/m,
+      [
+        "---",
+        "",
+        "::: warning",
+        // TODO: localize this text
+        `You are currently viewing the documentation for Minecraft ${oldVersion}. If you are looking for the documentation for a different version, please select the version you are using from the dropdown on the navigation bar.`,
+        ":::",
+        "",
+        "",
+      ].join("\n")
     )
-  ).json()) as any[];
-  const fabricApiVersion = fabricApiVersions[0]?.version_number;
-  if (!fabricApiVersion) {
-    console.error(`No Fabric API version found for Minecraft ${newVersion}`);
-    process.exit(1);
-  }
-  console.log(`Found Fabric API version ${fabricApiVersion}`);
+    .replace("link: ", `link: /${oldVersion}`)
+);
 
-  console.log(`Copying latest -> ${oldVersion}...`);
+console.log("Setting latest version in VersionReminder...");
+fs.writeFileSync(
+  "./.vitepress/theme/components/VersionReminder.vue",
+  fs
+    .readFileSync("./.vitepress/theme/components/VersionReminder.vue", "utf-8")
+    .replace(/const LATEST = "[^"]*";/, `const LATEST = "${newVersion}";`)
+);
 
-  // Copy ./reference/latest/** -> ./reference/oldVersion/**
-  fs.cpSync("./reference/latest", `./reference/${oldVersion}`, {
-    recursive: true,
-  });
-
-  // Update build.gradle in latest with new versions.
-  // def minecraftVersion = "XXX"
-  // def yarnVersion = "XXXXX"
-  // def fabricApiVersion = "XXXX"
-  const newBuildGradle = buildGradle
-    .replace(/def minecraftVersion = "([^"]+)"/, `def minecraftVersion = "${newVersion}"`)
-    .replace(/def yarnVersion = "([^"]+)"/, `def yarnVersion = "${yarnVersion}"`)
-    .replace(/def fabricApiVersion = "([^"]+)"/, `def fabricApiVersion = "${fabricApiVersion}"`);
-
-  fs.writeFileSync("./reference/latest/build.gradle", newBuildGradle);
-
-  console.log("Example mod has been bumped successfully.");
-  console.log(`Migrating content to versioned/${oldVersion}...`);
-
-  // Move all markdown files except README.md to versions/oldVersion
-  const markdownFiles = tinyglobby.globSync("**/*.md", {
-    ignore: ["README.md", "contributing.md", "versions/**/*.md", "node_modules/**/*"],
-  });
-
-  // Copy into versions/oldVersion and respect the directory structure.
-  for (const file of markdownFiles) {
-    const oldPath = `./${file}`;
-    const newPath = `./versions/${oldVersion}/${file}`;
-    fs.cpSync(oldPath, newPath);
-  }
-
-  console.log("Migration complete.");
-  console.log("Migration sidebars...");
-
-  const versionedSidebar = {
-    "/players/": players,
-    "/develop/": develop,
-  };
-
-  fs.writeFileSync(
-    `./.vitepress/sidebars/versioned/${oldVersion}.json`,
-    JSON.stringify(versionedSidebar, null, 2)
-  );
-
-  console.log("Migrated sidebars.");
-
-  console.log("Updating internal links...");
-
-  // Get all markdown files within versions/oldVersion
-  const versionedMarkdownFiles = tinyglobby.globSync(`versions/${oldVersion}/**/*.md`);
-  // Process all content
-  for (const file of versionedMarkdownFiles) {
-    const content = fs.readFileSync(file, "utf-8");
-
-    // Replace all instances of /reference/latest with /reference/oldVersion
-    const newContent = content.replace(/\/reference\/latest/g, `/reference/${oldVersion}`);
-    fs.writeFileSync(file, newContent);
-  }
-
-  console.log("Updated internal links.");
-
-  console.log("Adding warning box to index.md...");
-  fs.writeFileSync(
-    `./versions/${oldVersion}/index.md`,
-    fs
-      .readFileSync(`./versions/${oldVersion}/index.md`, "utf-8")
-      .replace(
-        /^---\n\n/m,
-        [
-          "---",
-          "",
-          "::: warning",
-          // TODO: localize this text
-          `You are currently viewing the documentation for Minecraft ${oldVersion}. If you are looking for the documentation for a different version, please select the version you are using from the dropdown on the navigation bar.`,
-          ":::",
-          "",
-          "",
-        ].join("\n")
-      )
-      .replace("link: ", `link: /${oldVersion}`)
-  );
-
-  console.log("Setting latest version in VersionReminder...");
-  fs.writeFileSync(
-    "./.vitepress/theme/components/VersionReminder.vue",
-    fs
-      .readFileSync("./.vitepress/theme/components/VersionReminder.vue", "utf-8")
-      .replace(/const LATEST = "[^"]*";/, `const LATEST = "${newVersion}";`)
-  );
-
-  console.log("DONE! Make sure everything's good before committing.");
-})();
+console.log("DONE! Make sure everything's good before committing.");


### PR DESCRIPTION
this pr exists to limit the size of #374
#388 should be merged to also get the changes to ChoiceComponent

- prettier:
```yaml
experimentalOperatorPosition: start
printWidth: 100
quoteProps: consistent
trailingComma: es5
```
- use arrow functions instead of `function`
- shorten some method and variable names
- prefer template strings to string concatenation
- use top-level await in update.ts
- report dead links outside of translated pages