### PR TITLE
Migrating Mappings

### DIFF
--- a/.vitepress/sidebars/develop.ts
+++ b/.vitepress/sidebars/develop.ts
@@ -287,6 +287,10 @@ export default [
         link: "/develop/text-and-translations",
       },
       {
+        text: "develop.misc.migrating_mappings",
+        link: "/develop/migrating-mappings",
+      },
+      {
         text: "develop.misc.debugging",
         link: "/develop/debugging",
       },

--- a/develop/migrating-mappings.md
+++ b/develop/migrating-mappings.md
@@ -61,7 +61,7 @@ You can now refresh the Gradle project in your IDE to apply your changes.
 
 That's the bulk of the work done! You'll now want to go through your source code to check and update any Mixin targets that may be outdated, and potentially fix any code that was not correctly remapped.
 
-Tools like [mappings.dev](https://mappings.dev/) or [Linkie](https://linkie.shedaniel.dev/) will be helpful to familiarize yourself with your new mappings.
+Tools like [mappings.dev](https://mappings.dev/) or [Linkie](https://linkie.shedaniel.dev/mappings?namespace=yarn&translateMode=ns&translateAs=mojang_raw&search=) will be helpful to familiarize yourself with your new mappings.
 
 ## Migrating to Yarn {#migrating-to-yarn}
 
@@ -107,7 +107,7 @@ You can now refresh the Gradle project in your IDE to apply your changes.
 
 That's the bulk of the work done! You'll now want to go through your source code to check and update any Mixin targets that may be outdated, and potentially fix any code that was not correctly remapped.
 
-Tools like [mappings.dev](https://mappings.dev/) or [Linkie](https://linkie.shedaniel.dev/) will be helpful to familiarize yourself with your new mappings.
+Tools like [mappings.dev](https://mappings.dev/) or [Linkie](https://linkie.shedaniel.dev/mappings?namespace=mojang_raw&translateMode=ns&translateAs=yarn&search=) will be helpful to familiarize yourself with your new mappings.
 
 ## Migrating Split Sources {#migrating-split-sources}
 

--- a/develop/migrating-mappings.md
+++ b/develop/migrating-mappings.md
@@ -9,11 +9,11 @@ authors:
 For best results, it's recommended to update to Loom 1.13 or above, as it allows for migrating Mixins, Access Wideners and client source sets.
 :::
 
-Fabric Loom makes use of obfuscation mappings in order to mod the game, usually either Fabric's own Yarn Mappings or the official Mojang Mappings. As a developer, you may wish to switch your mod's mappings from Yarn to Mojang Mappings, or vice versa, especially if you are planning to updating your mod to the next Game Drop after Mounts of Mayhem, which removes the obfuscation process so all mods use Mojang's names.
+Fabric Loom makes use of obfuscation mappings in order to mod the game, with mods usually being written in either Fabric's own Yarn Mappings or the official Mojang Mappings. As a developer, you may wish to switch your mod's mappings from Yarn to Mojang Mappings, or vice versa, especially if you are planning to updating your mod to the next Game Drop after Mounts of Mayhem, which removes the obfuscation process so all mods use Mojang's names.
 
 For that purpose, Loom allows semi-automatic updating of the mappings used in a Java codebase through the `migrateMappings` task.
 
-Loom does not support migrating code written in Kotlin. [Third party tools](https://github.com/Deftu/ReplayMod-Remap) are available.
+Loom does not support migrating code written in Kotlin.
 
 ## What Are Mappings? {#mappings}
 

--- a/develop/migrating-mappings.md
+++ b/develop/migrating-mappings.md
@@ -26,19 +26,21 @@ Historically, Minecraft: Java Edition has made use of obfuscation, which led to 
 
 Mojang have recently announced [they're removing code obfuscation from Minecraft: Java Edition](https://www.minecraft.net/en-us/article/removing-obfuscation-in-java-edition), and the Fabric Project followed up with [its plan for handling this change](https://fabricmc.net/2025/10/31/obfuscation.html).
 
-You may wish to migrate from Yarn to Mojang Mappings, or vice-versa, especially if you are planning on updating your mod past the Mounts of Mayhem game drop. To do this, Loom offers a semi-automated migration of the mappings through the `migrateMappings` task.
+You may wish to migrate from Yarn to Mojang Mappings, especially if you are planning on updating your mod past the Mounts of Mayhem game drop. To do this, or to switch to Yarn from another mapping set, Loom offers a semi-automated migration of the mappings through the `migrateMappings` task.
 
 Loom does not support migrating code written in Kotlin.
 
 ## What Are Mappings? {#mappings}
 
-Minecraft: Java Edition has been obfuscated since its release, which means replacing human-friendly class names like `Creeper` with something like `brc`. In order to easily mod it, Fabric Loom makes use of obfuscation maps: references which translate obfuscated class names, such as `brc`, back to human-friendly names like `CreeperEntity`.
+Minecraft: Java Edition has been obfuscated since its release, which means that its code had human-friendly class names like `Creeper` with something like `brc`. In order to easily mod it, Fabric Loom makes use of obfuscation maps: references which translate obfuscated class names, such as `brc`, back to human-friendly names like `CreeperEntity`.
 
 As a Fabric developer, you'll encounter three main sets of names:
 
 - **Intermediary**: The mapping set used by compiled Fabric mods; for example `brc` may become `class_1548`. The point behind Intermediary is offering a stable set of names across releases, as obfuscated class names change with each new version of Minecraft. This often allows mods built for one version to work on others, as long as the affected parts of the game haven't changed too much.
 - **Yarn**: an open-source mapping set developed by Fabric for humans to write mods. Most Fabric mods used Yarn Mappings, as they were the default before 2025. An example mapping might be `CreeperEntity`.
-- **Mojang Mappings**: The game's official obfuscation mappings, released by Mojang in 2019 to aid mod development. An example mapping might be `Creeper`.
+- **Mojang Mappings**: The game's official obfuscation mappings, released by Mojang in 2019 to aid mod development. Notably, Mojang's obfuscation mappings lack parameter names and Javadocs, which is why some users also layer [Parchment](https://parchmentmc.org/) over the official mappings. An example mapping might be `Creeper`.
+
+[The game drop following Mounts of Mayhem will be deobfuscated]((https://www.minecraft.net/en-us/article/removing-obfuscation-in-java-edition)) and include parameter names, so there won't be a need for any obfuscation mappings. If you are updating your mod to this version, you will need to move to Mojang's obfuscation mappings first before updating.
 
 ## Migrating to Mojang Mappings {#migrating-to-mojmap}
 

--- a/develop/migrating-mappings.md
+++ b/develop/migrating-mappings.md
@@ -5,8 +5,8 @@ authors:
   - cassiancc
 ---
 
-::: warning
-This automated process does not yet handle Mixins or reflection. Updated tooling is currently in the works that will fix these errors. This tooling will be available before the mandatory switch to Mojang names in a future version of Minecraft.
+::: info
+For best results, it's recommended to update to Loom 1.13 or above, as it allows for migrating Mixins, Access Wideners and client source sets.
 :::
 
 Fabric Loom makes use of obfuscation mappings in order to mod the game, usually either Fabric's own Yarn Mappings or the official Mojang Mappings. As a developer, you may wish to switch your mod's mappings from Yarn to Mojang Mappings, or vice versa, especially if you are planning to updating your mod to the next Game Drop after Mounts of Mayhem, which removes the obfuscation process so all mods use Mojang's names.
@@ -39,9 +39,13 @@ You can run this command in the terminal, prefixed with `./gradlew` on Linux/Mac
 
 ### Editing Your Sources {#editing-sources-mojmap}
 
-Your migrated sources will appear in `remappedSrc`. Verify that the migration produced valid migrated code.
+With the default configuration, your migrated sources will appear in `remappedSrc` rather than overwriting your existing sources. You'll need to copy the sources from `remappedSrc` to the original folder. Keep the original sources backed up just in case.
 
-Copy the sources from `remappedSrc` to the original folder. Keep the original sources backed up just in case.
+If you are using Loom 1.13 or above, you can use the program argument `--overrideInputsIHaveABackup` to replace your sources directly.
+
+```groovy
+migrateMappings --mappings "net.minecraft:mappings:1.21.10 --overrideInputsIHaveABackup"
+```
 
 ### Updating Gradle {#updating-gradle-mojmap}
 
@@ -77,9 +81,13 @@ You can run this command in the terminal, prefixed with `./gradlew` on Linux/Mac
 
 ### Editing Your Sources {#editing-sources-yarn}
 
-Your migrated sources will appear in `remappedSrc`. Verify that the migration produced valid migrated code.
+With the default configuration, your migrated sources will appear in `remappedSrc` rather than overwriting your existing sources. You'll need to copy the sources from `remappedSrc` to the original folder. Keep the original sources backed up just in case.
 
-Copy the sources from `remappedSrc` to the original folder. Keep the original sources backed up just in case.
+If you are using Loom 1.13 or above, you can use the program argument `--overrideInputsIHaveABackup` to replace your sources directly.
+
+```groovy
+migrateMappings --mappings "1.21.10+build.2 --overrideInputsIHaveABackup"
+```
 
 ### Updating Gradle {#updating-gradle-yarn}
 
@@ -109,10 +117,32 @@ That's the bulk of the work done! You'll now want to go through your source code
 
 Tools like [mappings.dev](https://mappings.dev/) or [Linkie](https://linkie.shedaniel.dev/mappings?namespace=mojang_raw&translateMode=ns&translateAs=yarn&search=) will be helpful to familiarize yourself with your new mappings.
 
-## Migrating Split Sources {#migrating-split-sources}
+## Additional Configurations {#additional-configurations}
 
-At this time, users of split sources currently need to migrate their main source set with the process above, then do the process again, specifying the path to their client source set. As a reference, the command to migrate a client source set to Mojang Mappings is below.
+### Migrating Split Sources {#migrating-split-sources}
+
+Loom 1.13 adds a new `migrateClientMappings` task that can be used to migrate your client sourceset to your new mappings. An example for migrating to Mojang Mappings can be seen below. If you are using an older version of Loom, see [other configurations](#other-configurations).
 
 ```groovy
-migrateMappings --mappings "net.minecraft:mappings:1.21.10" --input src/client/java
+migrateClientMappings --mappings "net.minecraft:mappings:1.21.10"
+```
+
+### Migrating Access Wideners {#migrating-access-wideners}
+
+Loom 1.13 adds a new `migrateClassTweakerMappings` task that can be used to migrate your access wideners to your new mappings. An example for migrating to Mojang Mappings can be seen below.
+
+```groovy
+migrateClassTweakerMappings --mappings "net.minecraft:mappings:1.21.10"
+```
+
+### Other Configurations {#other-configurations}
+
+- Specify from where to take your Java files with `--input path/to/source`. Default: `src/main/java`. You can use this to migrate a client sourceset by passing `--input src/client/java`.
+- Specify where to output the remapped source with `--output path/to/output`. Default: `remappedSrc`. You can use `src/main/java` here to avoid having to copy the remapped classes, but make sure you have a backup.
+- Specify a custom place to retrieve the mappings from with `--mappings some_group:some_artifact:some_version:some_qualifier`. Default: `net.fabricmc:yarn:<version-you-inputted>:v2`. Use `net.minecraft:mappings:<minecraft-version>` to migrate to official Mojang mappings.
+
+A complete example that migrates a client source set to Mojang Mappings, overwriting the existing source set is below.
+
+```groovy
+migrateMappings --input "src/client/java" --output "src/client/java" --mappings "net.minecraft:mappings:1.21.10"
 ```

--- a/develop/migrating-mappings.md
+++ b/develop/migrating-mappings.md
@@ -32,7 +32,7 @@ Loom does not support migrating code written in Kotlin.
 
 ## What Are Mappings? {#mappings}
 
-Minecraft: Java Edition has been obfuscated since its release, which means that its code had human-friendly class names like `Creeper` with something like `brc`. In order to easily mod it, Fabric Loom makes use of obfuscation maps: references which translate obfuscated class names, such as `brc`, back to human-friendly names like `CreeperEntity`.
+Minecraft: Java Edition has been obfuscated since its release, which means that its code had human-friendly class names like `Creeper` replaced with gibberish like `brc`. In order to easily mod it, Fabric Loom makes use of obfuscation maps: references which translate obfuscated class names, such as `brc`, back to human-friendly names like `CreeperEntity`.
 
 As a Fabric developer, you'll encounter three main sets of names:
 

--- a/develop/migrating-mappings.md
+++ b/develop/migrating-mappings.md
@@ -110,7 +110,7 @@ If you are migrating from Mojang Mappings, you can now replace your mappings in 
 
 **`gradle.properties`**
 
-```groovy
+```properties
 yarn_mappings=1.21.10+build.2
 ```
 

--- a/develop/migrating-mappings.md
+++ b/develop/migrating-mappings.md
@@ -3,31 +3,46 @@ title: Migrating Mappings
 description: Learn how to migrate your mod's obfuscation mappings.
 authors:
   - cassiancc
+  - florensie
+  - Friendly-Banana
+  - IMB11
+  - jamierocks
+  - JamiesWhiteShirt
+  - MildestToucan
+  - modmuss50
+  - natanfudge
+  - Spinoscythe
+  - UpcraftLP
+authors-nogithub:
+  - asie
+  - basil4088
 ---
 
 ::: info
 For best results, it's recommended to update to Loom 1.13 or above, as it allows for migrating Mixins, Access Wideners and client source sets.
 :::
 
-Fabric Loom makes use of obfuscation mappings in order to mod the game, with mods usually being written in either Fabric's own Yarn Mappings or the official Mojang Mappings. As a developer, you may wish to switch your mod's mappings from Yarn to Mojang Mappings, or vice versa, especially if you are planning to updating your mod to the next Game Drop after Mounts of Mayhem, which removes the obfuscation process so all mods use Mojang's names.
+Historically, Minecraft: Java Edition has made use of obfuscation, which led to the development of obfuscation maps that Fabric Loom uses for modding. There were two choices: either Fabric's own Yarn mappings, or the official Mojang mappings.
 
-For that purpose, Loom allows semi-automatic updating of the mappings used in a Java codebase through the `migrateMappings` task.
+Mojang have recently announced [they're removing code obfuscation from Minecraft: Java Edition](https://www.minecraft.net/en-us/article/removing-obfuscation-in-java-edition), and the Fabric Project followed up with [its plan for handling this change](https://fabricmc.net/2025/10/31/obfuscation.html).
+
+You may wish to migrate from Yarn to Mojang Mappings, or vice-versa, especially if you are planning on updating your mod past the Mounts of Mayhem game drop. To do this, Loom offers a semi-automated migration of the mappings through the `migrateMappings` task.
 
 Loom does not support migrating code written in Kotlin.
 
 ## What Are Mappings? {#mappings}
 
-Minecraft; Java Edition has been obfuscated since its release - replacing human friendly names like `Creeper` with something like `brc`. In order to effectively mod it, Fabric Loom makes use of obsucation maps, reference material which translates obfuscated class names like `brc` into human-friendly names like `CreeperEntity`.
+Minecraft: Java Edition has been obfuscated since its release, which means replacing human-friendly class names like `Creeper` with something like `brc`. In order to easily mod it, Fabric Loom makes use of obfuscation maps: references which translate obfuscated class names, such as `brc`, back to human-friendly names like `CreeperEntity`.
 
 As a Fabric developer, you'll encounter three main sets of names:
 
-- **Intermediary**: The mapping set used by compiled Fabric mods, making use of numbers instead of names. These names are stable, so they do not change as much between releases are other mappings, allowing mods meant for one version to work on others, as long as the game itself hasn't changed too much. An example mapping would be `class_1548`.
-- **Yarn**: An open source mapping set developed by Fabric to mod the game with. Most Fabric mods used Yarn Mappings, as they were the default prior to 2025. An example mapping would be `CreeperEntity`.
-- **Mojang Mappings**: The game's official obfuscation mappings, released by Mojang in 2019 in order to aid mod development. An example mapping would be `Creeper`.
+- **Intermediary**: The mapping set used by compiled Fabric mods; for example `brc` may become `class_1548`. The point behind Intermediary is offering a stable set of names across releases, as obfuscated class names change with each new version of Minecraft. This often allows mods built for one version to work on others, as long as the affected parts of the game haven't changed too much.
+- **Yarn**: an open-source mapping set developed by Fabric for humans to write mods. Most Fabric mods used Yarn Mappings, as they were the default before 2025. An example mapping might be `CreeperEntity`.
+- **Mojang Mappings**: The game's official obfuscation mappings, released by Mojang in 2019 to aid mod development. An example mapping might be `Creeper`.
 
 ## Migrating to Mojang Mappings {#migrating-to-mojmap}
 
-First, you'll need a `migrateMappings` command that will convert your current mappings to Mojang Mappings. For example, the following command would migrate to Mojang Mappings for 1.21.10.
+First, you need to run a `migrateMappings` command that will migrate your current mappings to Mojang Mappings. For example, the following command would migrate to Mojang Mappings for 1.21.10:
 
 ```groovy
 migrateMappings --mappings "net.minecraft:mappings:1.21.10"
@@ -39,7 +54,7 @@ You can run this command in the terminal, prefixed with `./gradlew` on Linux/Mac
 
 ### Editing Your Sources {#editing-sources-mojmap}
 
-With the default configuration, your migrated sources will appear in `remappedSrc` rather than overwriting your existing sources. You'll need to copy the sources from `remappedSrc` to the original folder. Keep the original sources backed up just in case.
+By default, the migrated source code will appear in `remappedSrc`, rather than overwriting your existing project. You'll need to copy the sources from `remappedSrc` to the original folder. Make sure to back up the original sources, just in case.
 
 If you are using Loom 1.13 or above, you can use the program argument `--overrideInputsIHaveABackup` to replace your sources directly.
 
@@ -69,7 +84,7 @@ Tools like [mappings.dev](https://mappings.dev/) or [Linkie](https://linkie.shed
 
 ## Migrating to Yarn {#migrating-to-yarn}
 
-First, you'll need a `migrateMappings` command that will convert your current mappings to Yarn Mappings. This can be easily found on [the Develop site](https://fabricmc.net/develop) under Mappings Migration, and an example is given below as well.
+First, you need to run a `migrateMappings` command that will convert your current mappings to Yarn Mappings. This can be found on [the Develop site](https://fabricmc.net/develop) under Mappings Migration. For example:
 
 ```groovy
 migrateMappings --mappings "1.21.10+build.2"
@@ -81,7 +96,7 @@ You can run this command in the terminal, prefixed with `./gradlew` on Linux/Mac
 
 ### Editing Your Sources {#editing-sources-yarn}
 
-With the default configuration, your migrated sources will appear in `remappedSrc` rather than overwriting your existing sources. You'll need to copy the sources from `remappedSrc` to the original folder. Keep the original sources backed up just in case.
+By default, the migrated source code will appear in `remappedSrc`, rather than overwriting your existing project. You'll need to copy the sources from `remappedSrc` to the original folder. Make sure to back up the original sources, just in case.
 
 If you are using Loom 1.13 or above, you can use the program argument `--overrideInputsIHaveABackup` to replace your sources directly.
 
@@ -91,7 +106,7 @@ migrateMappings --mappings "1.21.10+build.2 --overrideInputsIHaveABackup"
 
 ### Updating Gradle {#updating-gradle-yarn}
 
-If you are coming from Mojang Mappings, you can now replace your mappings in your `build.gradle`'s dependencies section with Yarn Mappings. Make sure to also update your `gradle.properties` file with the Yarn version specified on [the Develop site](https://fabricmc.net/develop).
+If you are migrating from Mojang Mappings, you can now replace your mappings in your `build.gradle`'s dependencies section with Yarn Mappings. Make sure to also update your `gradle.properties` file with the Yarn version specified on [the Develop site](https://fabricmc.net/develop).
 
 **`gradle.properties`**
 
@@ -121,15 +136,17 @@ Tools like [mappings.dev](https://mappings.dev/) or [Linkie](https://linkie.shed
 
 ### Migrating Split Sources {#migrating-split-sources}
 
-Loom 1.13 adds a new `migrateClientMappings` task that can be used to migrate your client sourceset to your new mappings. An example for migrating to Mojang Mappings can be seen below. If you are using an older version of Loom, see [other configurations](#other-configurations).
+Loom 1.13 adds a new `migrateClientMappings` task that can be used to migrate your client sourceset to your new mappings. For example, to migrate to Mojang Mappings: 
 
 ```groovy
 migrateClientMappings --mappings "net.minecraft:mappings:1.21.10"
 ```
 
+If you are using an older version of Loom, see [other configurations](#other-configurations).
+
 ### Migrating Access Wideners {#migrating-access-wideners}
 
-Loom 1.13 adds a new `migrateClassTweakerMappings` task that can be used to migrate your access wideners to your new mappings. An example for migrating to Mojang Mappings can be seen below.
+Loom 1.13 adds a new `migrateClassTweakerMappings` task that can be used to migrate your access wideners to your new mappings. For example, to migrate to Mojang Mappings:
 
 ```groovy
 migrateClassTweakerMappings --mappings "net.minecraft:mappings:1.21.10"
@@ -137,11 +154,11 @@ migrateClassTweakerMappings --mappings "net.minecraft:mappings:1.21.10"
 
 ### Other Configurations {#other-configurations}
 
-- Specify from where to take your Java files with `--input path/to/source`. Default: `src/main/java`. You can use this to migrate a client sourceset by passing `--input src/client/java`.
-- Specify where to output the remapped source with `--output path/to/output`. Default: `remappedSrc`. You can use `src/main/java` here to avoid having to copy the remapped classes, but make sure you have a backup.
+- Specify where to take your Java source files from with `--input path/to/source`. Default: `src/main/java`. You can use this to migrate a client sourceset by passing `--input src/client/java`.
+- Specify where to output the remapped source with `--output path/to/output`. Default: `remappedSrc`. You can use `src/main/java` here to overwrite existing sources, but make sure you have a backup.
 - Specify a custom place to retrieve the mappings from with `--mappings some_group:some_artifact:some_version:some_qualifier`. Default: `net.fabricmc:yarn:<version-you-inputted>:v2`. Use `net.minecraft:mappings:<minecraft-version>` to migrate to official Mojang mappings.
 
-A complete example that migrates a client source set to Mojang Mappings, overwriting the existing source set is below.
+For example, to migrate a client source set to Mojang Mappings in-place (overwriting the existing sources):
 
 ```groovy
 migrateMappings --input "src/client/java" --output "src/client/java" --mappings "net.minecraft:mappings:1.21.10"

--- a/develop/migrating-mappings.md
+++ b/develop/migrating-mappings.md
@@ -57,7 +57,7 @@ First, you need to run a `migrateMappings` command that will migrate your curren
 ```
 
 ```sh:no-line-numbers [IntelliJ]
-migrateMappings migrateMappings --mappings "net.minecraft:mappings:1.21.10"
+migrateMappings --mappings "net.minecraft:mappings:1.21.10"
 ```
 
 :::
@@ -81,7 +81,7 @@ If you are using Loom 1.13 or above, you can use the program argument `--overrid
 ```
 
 ```sh:no-line-numbers [IntelliJ]
-migrateMappings migrateMappings --mappings "net.minecraft:mappings:1.21.10" --overrideInputsIHaveABackup
+migrateMappings --mappings "net.minecraft:mappings:1.21.10" --overrideInputsIHaveABackup
 ```
 
 :::
@@ -121,7 +121,7 @@ First, you need to run a `migrateMappings` command that will convert your curren
 ```
 
 ```sh:no-line-numbers [IntelliJ]
-migrateMappings migrateMappings --mappings "1.21.10+build.2"
+migrateMappings --mappings "1.21.10+build.2"
 ```
 
 :::

--- a/develop/migrating-mappings.md
+++ b/develop/migrating-mappings.md
@@ -59,7 +59,7 @@ By default, the migrated source code will appear in `remappedSrc`, rather than o
 If you are using Loom 1.13 or above, you can use the program argument `--overrideInputsIHaveABackup` to replace your sources directly.
 
 ```groovy
-migrateMappings --mappings "net.minecraft:mappings:1.21.10 --overrideInputsIHaveABackup"
+migrateMappings --mappings "net.minecraft:mappings:1.21.10" --overrideInputsIHaveABackup
 ```
 
 ### Updating Gradle {#updating-gradle-mojmap}

--- a/develop/migrating-mappings.md
+++ b/develop/migrating-mappings.md
@@ -1,0 +1,118 @@
+---
+title: Migrating Mappings
+description: Learn how to migrate your mod's obfuscation mappings.
+authors:
+  - cassiancc
+---
+
+::: warning
+This automated process does not yet handle Mixins or reflection. Updated tooling is currently in the works that will fix these errors. This tooling will be available before the mandatory switch to Mojang names in a future version of Minecraft.
+:::
+
+Fabric Loom makes use of obfuscation mappings in order to mod the game, usually either Fabric's own Yarn Mappings or the official Mojang Mappings. As a developer, you may wish to switch your mod's mappings from Yarn to Mojang Mappings, or vice versa, especially if you are planning to updating your mod to the next Game Drop after Mounts of Mayhem, which removes the obfuscation process so all mods use Mojang's names.
+
+For that purpose, Loom allows semi-automatic updating of the mappings used in a Java codebase through the `migrateMappings` task.
+
+Loom does not support migrating code written in Kotlin. [Third party tools](https://github.com/Deftu/ReplayMod-Remap) are available.
+
+## What Are Mappings? {#mappings}
+
+Minecraft; Java Edition has been obfuscated since its release - replacing human friendly names like `Creeper` with something like `brc`. In order to effectively mod it, Fabric Loom makes use of obsucation maps, reference material which translates obfuscated class names like `brc` into human-friendly names like `CreeperEntity`.
+
+As a Fabric developer, you'll encounter three main sets of names:
+
+- **Intermediary**: The mapping set used by compiled Fabric mods, making use of numbers instead of names. These names are stable, so they do not change as much between releases are other mappings, allowing mods meant for one version to work on others, as long as the game itself hasn't changed too much. An example mapping would be `class_1548`.
+- **Yarn**: An open source mapping set developed by Fabric to mod the game with. Most Fabric mods used Yarn Mappings, as they were the default prior to 2025. An example mapping would be `CreeperEntity`.
+- **Mojang Mappings**: The game's official obfuscation mappings, released by Mojang in 2019 in order to aid mod development. An example mapping would be `Creeper`.
+
+## Migrating to Mojang Mappings {#migrating-to-mojmap}
+
+First, you'll need a `migrateMappings` command that will convert your current mappings to Mojang Mappings. For example, the following command would migrate to Mojang Mappings for 1.21.10.
+
+```groovy
+migrateMappings --mappings "net.minecraft:mappings:1.21.10"
+```
+
+You can replace `1.21.10` with the version of Minecraft you are migrating from. This must be the same version of Minecraft you are currently running. **Do not modify your `gradle.properties` or `build.gradle` yet!**
+
+You can run this command in the terminal, prefixed with `./gradlew` on Linux/MacOS or `./gradlew.bat` on Windows, or by adding it as a run configuration in IntelliJ Idea.
+
+### Editing Your Sources {#editing-sources-mojmap}
+
+Your migrated sources will appear in `remappedSrc`. Verify that the migration produced valid migrated code.
+
+Copy the sources from `remappedSrc` to the original folder. Keep the original sources backed up just in case.
+
+### Updating Gradle {#updating-gradle-mojmap}
+
+If you are coming from Yarn, you can now replace your mappings in your `build.gradle`'s dependencies section with Mojang Mappings.
+
+```groovy
+dependencies {
+    [...]
+      mappings loom.officialMojangMappings()
+//    mappings "net.fabricmc:yarn${project.yarn_mappings}:v2"
+}
+```
+
+You can now refresh the Gradle project in your IDE to apply your changes.
+
+### Final Changes {#final-changes-mojmap}
+
+That's the bulk of the work done! You'll now want to go through your source code to check and update any Mixin targets that may be outdated, and potentially fix any code that was not correctly remapped.
+
+Tools like [mappings.dev](https://mappings.dev/) or [Linkie](https://linkie.shedaniel.dev/) will be helpful to familiarize yourself with your new mappings.
+
+## Migrating to Yarn {#migrating-to-yarn}
+
+First, you'll need a `migrateMappings` command that will convert your current mappings to Yarn Mappings. This can be easily found on [the Develop site](https://fabricmc.net/develop) under Mappings Migration, and an example is given below as well.
+
+```groovy
+migrateMappings --mappings "1.21.10+build.2"
+```
+
+You can replace `1.21.10` with the version of Minecraft you are migrating from. This must be the same version of Minecraft you are currently running. **Do not modify your `gradle.properties` or `build.gradle` yet!**
+
+You can run this command in the terminal, prefixed with `./gradlew` on Linux/MacOS or `./gradlew.bat` on Windows, or by adding it as a run configuration in IntelliJ Idea.
+
+### Editing Your Sources {#editing-sources-yarn}
+
+Your migrated sources will appear in `remappedSrc`. Verify that the migration produced valid migrated code.
+
+Copy the sources from `remappedSrc` to the original folder. Keep the original sources backed up just in case.
+
+### Updating Gradle {#updating-gradle-yarn}
+
+If you are coming from Mojang Mappings, you can now replace your mappings in your `build.gradle`'s dependencies section with Yarn Mappings. Make sure to also update your `gradle.properties` file with the Yarn version specified on [the Develop site](https://fabricmc.net/develop).
+
+**`gradle.properties`**
+
+```groovy
+yarn_mappings=1.21.10+build.2
+```
+
+**`build.gradle`**
+
+```groovy
+dependencies {
+    [...]
+//   mappings loom.officialMojangMappings()
+     mappings "net.fabricmc:yarn${project.yarn_mappings}:v2"
+}
+```
+
+You can now refresh the Gradle project in your IDE to apply your changes.
+
+### Final Changes {#final-changes-yarn}
+
+That's the bulk of the work done! You'll now want to go through your source code to check and update any Mixin targets that may be outdated, and potentially fix any code that was not correctly remapped.
+
+Tools like [mappings.dev](https://mappings.dev/) or [Linkie](https://linkie.shedaniel.dev/) will be helpful to familiarize yourself with your new mappings.
+
+## Migrating Split Sources {#migrating-split-sources}
+
+At this time, users of split sources currently need to migrate their main source set with the process above, then do the process again, specifying the path to their client source set. As a reference, the command to migrate a client source set to Mojang Mappings is below.
+
+```groovy
+migrateMappings --mappings "net.minecraft:mappings:1.21.10" --input src/client/java
+```

--- a/develop/migrating-mappings.md
+++ b/develop/migrating-mappings.md
@@ -136,7 +136,7 @@ Tools like [mappings.dev](https://mappings.dev/) or [Linkie](https://linkie.shed
 
 ### Migrating Split Sources {#migrating-split-sources}
 
-Loom 1.13 adds a new `migrateClientMappings` task that can be used to migrate your client sourceset to your new mappings. For example, to migrate to Mojang Mappings: 
+Loom 1.13 adds a new `migrateClientMappings` task that can be used to migrate your client sourceset to your new mappings. For example, to migrate to Mojang Mappings:
 
 ```groovy
 migrateClientMappings --mappings "net.minecraft:mappings:1.21.10"

--- a/develop/migrating-mappings.md
+++ b/develop/migrating-mappings.md
@@ -44,13 +44,23 @@ As a Fabric developer, you'll encounter three main sets of names:
 
 First, you need to run a `migrateMappings` command that will migrate your current mappings to Mojang Mappings. For example, the following command would migrate to Mojang Mappings for 1.21.10:
 
-```groovy
-migrateMappings --mappings "net.minecraft:mappings:1.21.10"
+::: code-group
+
+```powershell:no-line-numbers [Windows]
+./gradlew.bat migrateMappings --mappings "net.minecraft:mappings:1.21.10"
 ```
 
-You can replace `1.21.10` with the version of Minecraft you are migrating from. This must be the same version of Minecraft you are currently running. **Do not modify your `gradle.properties` or `build.gradle` yet!**
+```sh:no-line-numbers [macOS/Linux]
+./gradlew migrateMappings --mappings "net.minecraft:mappings:1.21.10"
+```
 
-You can run this command in the terminal, prefixed with `./gradlew` on Linux/MacOS or `./gradlew.bat` on Windows, or by adding it as a run configuration in IntelliJ Idea.
+```sh:no-line-numbers [IntelliJ]
+migrateMappings migrateMappings --mappings "net.minecraft:mappings:1.21.10"
+```
+
+:::
+
+You can replace `1.21.10` with the version of Minecraft you are migrating from. This must be the same version of Minecraft you are currently running. **Do not modify your `gradle.properties` or `build.gradle` yet!**
 
 ### Editing Your Sources {#editing-sources-mojmap}
 
@@ -58,9 +68,21 @@ By default, the migrated source code will appear in `remappedSrc`, rather than o
 
 If you are using Loom 1.13 or above, you can use the program argument `--overrideInputsIHaveABackup` to replace your sources directly.
 
-```groovy
-migrateMappings --mappings "net.minecraft:mappings:1.21.10" --overrideInputsIHaveABackup
+::: code-group
+
+```powershell:no-line-numbers [Windows]
+./gradlew.bat migrateMappings --mappings "net.minecraft:mappings:1.21.10" --overrideInputsIHaveABackup
 ```
+
+```sh:no-line-numbers [macOS/Linux]
+./gradlew migrateMappings --mappings "net.minecraft:mappings:1.21.10" --overrideInputsIHaveABackup
+```
+
+```sh:no-line-numbers [IntelliJ]
+migrateMappings migrateMappings --mappings "net.minecraft:mappings:1.21.10" --overrideInputsIHaveABackup
+```
+
+:::
 
 ### Updating Gradle {#updating-gradle-mojmap}
 
@@ -86,13 +108,23 @@ Tools like [mappings.dev](https://mappings.dev/) or [Linkie](https://linkie.shed
 
 First, you need to run a `migrateMappings` command that will convert your current mappings to Yarn Mappings. This can be found on [the Develop site](https://fabricmc.net/develop) under Mappings Migration. For example:
 
-```groovy
-migrateMappings --mappings "1.21.10+build.2"
+::: code-group
+
+```powershell:no-line-numbers [Windows]
+./gradlew.bat migrateMappings --mappings "1.21.10+build.2"
 ```
 
-You can replace `1.21.10` with the version of Minecraft you are migrating from. This must be the same version of Minecraft you are currently running. **Do not modify your `gradle.properties` or `build.gradle` yet!**
+```sh:no-line-numbers [macOS/Linux]
+./gradlew migrateMappings --mappings "1.21.10+build.2"
+```
 
-You can run this command in the terminal, prefixed with `./gradlew` on Linux/MacOS or `./gradlew.bat` on Windows, or by adding it as a run configuration in IntelliJ Idea.
+```sh:no-line-numbers [IntelliJ]
+migrateMappings migrateMappings --mappings "1.21.10+build.2"
+```
+
+:::
+
+You can replace `1.21.10` with the version of Minecraft you are migrating from. This must be the same version of Minecraft you are currently running. **Do not modify your `gradle.properties` or `build.gradle` yet!**
 
 ### Editing Your Sources {#editing-sources-yarn}
 
@@ -100,9 +132,21 @@ By default, the migrated source code will appear in `remappedSrc`, rather than o
 
 If you are using Loom 1.13 or above, you can use the program argument `--overrideInputsIHaveABackup` to replace your sources directly.
 
-```groovy
+::: code-group
+
+```powershell:no-line-numbers [Windows]
+./gradlew.bat migrateMappings --mappings "1.21.10+build.2 --overrideInputsIHaveABackup"
+```
+
+```sh:no-line-numbers [macOS/Linux]
+./gradlew migrateMappings --mappings "1.21.10+build.2 --overrideInputsIHaveABackup"
+```
+
+```sh:no-line-numbers [IntelliJ]
 migrateMappings --mappings "1.21.10+build.2 --overrideInputsIHaveABackup"
 ```
+
+:::
 
 ### Updating Gradle {#updating-gradle-yarn}
 
@@ -138,9 +182,21 @@ Tools like [mappings.dev](https://mappings.dev/) or [Linkie](https://linkie.shed
 
 Loom 1.13 adds a new `migrateClientMappings` task that can be used to migrate your client sourceset to your new mappings. For example, to migrate to Mojang Mappings:
 
-```groovy
+::: code-group
+
+```powershell:no-line-numbers [Windows]
+./gradlew.bat migrateClientMappings --mappings "net.minecraft:mappings:1.21.10"
+```
+
+```sh:no-line-numbers [macOS/Linux]
+./gradlew migrateClientMappings --mappings "net.minecraft:mappings:1.21.10"
+```
+
+```sh:no-line-numbers [IntelliJ]
 migrateClientMappings --mappings "net.minecraft:mappings:1.21.10"
 ```
+
+:::
 
 If you are using an older version of Loom, see [other configurations](#other-configurations).
 
@@ -148,9 +204,21 @@ If you are using an older version of Loom, see [other configurations](#other-con
 
 Loom 1.13 adds a new `migrateClassTweakerMappings` task that can be used to migrate your access wideners to your new mappings. For example, to migrate to Mojang Mappings:
 
-```groovy
+::: code-group
+
+```powershell:no-line-numbers [Windows]
+./gradlew.bat migrateClassTweakerMappings --mappings "net.minecraft:mappings:1.21.10"
+```
+
+```sh:no-line-numbers [macOS/Linux]
+./gradlew migrateClassTweakerMappings --mappings "net.minecraft:mappings:1.21.10"
+```
+
+```sh:no-line-numbers [IntelliJ]
 migrateClassTweakerMappings --mappings "net.minecraft:mappings:1.21.10"
 ```
+
+:::
 
 ### Other Configurations {#other-configurations}
 
@@ -160,6 +228,18 @@ migrateClassTweakerMappings --mappings "net.minecraft:mappings:1.21.10"
 
 For example, to migrate a client source set to Mojang Mappings in-place (overwriting the existing sources):
 
-```groovy
+::: code-group
+
+```powershell:no-line-numbers [Windows]
+./gradlew.bat migrateMappings --input "src/client/java" --output "src/client/java" --mappings "net.minecraft:mappings:1.21.10"
+```
+
+```sh:no-line-numbers [macOS/Linux]
+./gradlew migrateMappings --input "src/client/java" --output "src/client/java" --mappings "net.minecraft:mappings:1.21.10"
+```
+
+```sh:no-line-numbers [IntelliJ]
 migrateMappings --input "src/client/java" --output "src/client/java" --mappings "net.minecraft:mappings:1.21.10"
 ```
+
+:::

--- a/develop/migrating-mappings.md
+++ b/develop/migrating-mappings.md
@@ -66,11 +66,11 @@ migrateMappings --mappings "net.minecraft:mappings:1.21.10 --overrideInputsIHave
 
 If you are coming from Yarn, you can now replace your mappings in your `build.gradle`'s dependencies section with Mojang Mappings.
 
-```groovy
+```diff
 dependencies {
     [...]
-      mappings loom.officialMojangMappings()
-//    mappings "net.fabricmc:yarn${project.yarn_mappings}:v2"
+    mappings loom.officialMojangMappings() # [!code ++]
+    mappings "net.fabricmc:yarn${project.yarn_mappings}:v2" # [!code --]
 }
 ```
 
@@ -78,7 +78,7 @@ You can now refresh the Gradle project in your IDE to apply your changes.
 
 ### Final Changes {#final-changes-mojmap}
 
-That's the bulk of the work done! You'll now want to go through your source code to check and update any Mixin targets that may be outdated, and potentially fix any code that was not correctly remapped.
+That's the bulk of the work done! You'll now want to go through your source code to check for any potentially outdated Mixin targets or code that was not remapped.
 
 Tools like [mappings.dev](https://mappings.dev/) or [Linkie](https://linkie.shedaniel.dev/mappings?namespace=yarn&translateMode=ns&translateAs=mojang_raw&search=) will be helpful to familiarize yourself with your new mappings.
 
@@ -116,11 +116,11 @@ yarn_mappings=1.21.10+build.2
 
 **`build.gradle`**
 
-```groovy
+```diff
 dependencies {
     [...]
-//   mappings loom.officialMojangMappings()
-     mappings "net.fabricmc:yarn${project.yarn_mappings}:v2"
+    mappings loom.officialMojangMappings() # [!code --]
+    mappings "net.fabricmc:yarn${project.yarn_mappings}:v2" # [!code ++]
 }
 ```
 
@@ -128,7 +128,7 @@ You can now refresh the Gradle project in your IDE to apply your changes.
 
 ### Final Changes {#final-changes-yarn}
 
-That's the bulk of the work done! You'll now want to go through your source code to check and update any Mixin targets that may be outdated, and potentially fix any code that was not correctly remapped.
+That's the bulk of the work done! You'll now want to go through your source code to check for any potentially outdated Mixin targets or code that was not remapped.
 
 Tools like [mappings.dev](https://mappings.dev/) or [Linkie](https://linkie.shedaniel.dev/mappings?namespace=mojang_raw&translateMode=ns&translateAs=yarn&search=) will be helpful to familiarize yourself with your new mappings.
 

--- a/develop/migrating-mappings.md
+++ b/develop/migrating-mappings.md
@@ -66,11 +66,11 @@ migrateMappings --mappings "net.minecraft:mappings:1.21.10 --overrideInputsIHave
 
 If you are coming from Yarn, you can now replace your mappings in your `build.gradle`'s dependencies section with Mojang Mappings.
 
-```diff
+```groovy
 dependencies {
     [...]
-    mappings loom.officialMojangMappings() # [!code ++]
-    mappings "net.fabricmc:yarn${project.yarn_mappings}:v2" # [!code --]
+    mappings "net.fabricmc:yarn${project.yarn_mappings}:v2" // [!code --]
+    mappings loom.officialMojangMappings() // [!code ++]
 }
 ```
 
@@ -116,11 +116,11 @@ yarn_mappings=1.21.10+build.2
 
 **`build.gradle`**
 
-```diff
+```groovy
 dependencies {
     [...]
-    mappings loom.officialMojangMappings() # [!code --]
-    mappings "net.fabricmc:yarn${project.yarn_mappings}:v2" # [!code ++]
+    mappings loom.officialMojangMappings() // [!code --]
+    mappings "net.fabricmc:yarn${project.yarn_mappings}:v2" // [!code ++]
 }
 ```
 

--- a/sidebar_translations.json
+++ b/sidebar_translations.json
@@ -70,6 +70,7 @@
   "develop.misc.networking": "Networking",
   "develop.misc.text_and_translations": "Text and Translations",
   "develop.misc.debugging": "Debugging Mods",
+  "develop.misc.migrating_mappings": "Migrating Mappings",
   "develop.misc.automatic_testing": "Automated Testing",
   "develop.misc.loom": "Loom Gradle Plugin",
   "develop.misc.loom.fabric_api": "Fabric API DSL",


### PR DESCRIPTION
An expanded and hopefully more user friendly draft of the [Migrating Mappings page from the Fabric Wiki](https://wiki.fabricmc.net/tutorial:migratemappings), making better use of codeblocks and including some basic information on what mappings are.

Unless further objections are made, this will be merged tomorrow alongside the release of Loom 1.13.