### PR TITLE
Fix Incorrect Section About Event Callbacks

### DIFF
--- a/develop/events.md
+++ b/develop/events.md
@@ -31,9 +31,7 @@ Callbacks are a piece of code that is passed as an argument to an event. When th
 
 ### Callback Interfaces {#callback-interfaces}
 
-Each event has a corresponding callback interface, conventionally named `<EventName>Callback`. Callbacks are registered by calling `register()` method on an event instance, with an instance of the callback interface as the argument.
-
-All event callback interfaces provided by Fabric API can be found in the `net.fabricmc.fabric.api.event` package.
+Each event has a corresponding callback interface. Callbacks are registered by calling `register()` method on an event instance, with an instance of the callback interface as the argument.
 
 ## Listening to Events {#listening-to-events}
 


### PR DESCRIPTION
As discussed here: [#docs](https://discord.com/channels/507304429255393322/1208846408552030238/1444143328785338518)

Closes https://github.com/FabricMC/fabric-docs/issues/416

Fabric API itself seems to be inconsistent when it comes to callback naming. So the line about naming convention is removed. 

Since not all events are in a single `event` package, that line is also removed.