### PR TITLE
Call `setDirty()` Only When Data is Changed

### DIFF
--- a/develop/saved-data.md
+++ b/develop/saved-data.md
@@ -50,6 +50,10 @@ Then we can build a Codec.
 
 @[code lang=java transcludeWith=:::codec](@/reference/latest/src/main/java/com/example/docs/saveddata/SavedBlockData.java)
 
+We should call `setDirty()` when data is actually modified, so Minecraft knows it should be saved to the disk.
+
+@[code lang=java transcludeWith=:::set_dirty](@/reference/latest/src/main/java/com/example/docs/saveddata/SavedBlockData.java)
+
 Finally, we're required to have a `SavedDataType` that describes our saved data. The first argument corresponds to the name of the file that will be created in the `data` directory of the world.
 
 @[code lang=java transcludeWith=:::type](@/reference/latest/src/main/java/com/example/docs/saveddata/SavedBlockData.java)

--- a/reference/latest/src/main/java/com/example/docs/saveddata/SavedBlockData.java
+++ b/reference/latest/src/main/java/com/example/docs/saveddata/SavedBlockData.java
@@ -43,9 +43,15 @@ public class SavedBlockData extends SavedData {
 		return blocksBroken;
 	}
 
+	// :::set_dirty
 	public void incrementBlocksBroken() {
 		blocksBroken++;
+
+		// If saved data is not marked dirty, nothing will be saved when Minecraft closes.
+		// You should only mark saved data as dirty when there was actually a change.
+		setDirty();
 	}
+	// :::set_dirty
 	// :::basic_structure
 	// :::method
 	public static SavedBlockData getSavedBlockData(MinecraftServer server) {
@@ -60,15 +66,7 @@ public class SavedBlockData extends SavedData {
 		// instance and stores it inside the 'DimensionDataStorage'.
 		// Subsequent calls to 'computeIfAbsent' returns the saved 'SavedBlockData' NBT on disk to the Codec in our type,
 		// using the Codec to decode the NBT into our saved data.
-		SavedBlockData savedData = level.getDataStorage().computeIfAbsent(TYPE);
-
-		// If saved data is not marked dirty, nothing will be saved when Minecraft closes.
-		// Technically it's 'cleaner' if you only mark saved data as dirty when there was actually a change,
-		// but the vast majority of mod developers are just going to be confused when their data isn't being saved,
-		// and so it's best just to 'setDirty' for them.
-		savedData.setDirty();
-
-		return savedData;
+		return level.getDataStorage().computeIfAbsent(TYPE);
 	}
 	// :::method
 	// :::basic_structure

--- a/reference/latest/src/main/java/com/example/docs/saveddata/SavedBlockData.java
+++ b/reference/latest/src/main/java/com/example/docs/saveddata/SavedBlockData.java
@@ -48,7 +48,6 @@ public class SavedBlockData extends SavedData {
 		blocksBroken++;
 
 		// If saved data is not marked dirty, nothing will be saved when Minecraft closes.
-		// You should only mark saved data as dirty when there was actually a change.
 		setDirty();
 	}
 	// :::set_dirty


### PR DESCRIPTION
[As pointed out on Discord](https://discord.com/channels/507304429255393322/507982478276034570/1446407771703742576), we mark the saved data state as dirty on every load. This should be done only when the data is actually changed.