### PR TITLE
Fix Transclusions in Basic Rendering Concepts

### DIFF
--- a/develop/rendering/basic-concepts.md
+++ b/develop/rendering/basic-concepts.md
@@ -125,7 +125,13 @@ Additionally, the code below does not fully match the explanation above: you do 
 Read the important update above for more information.
 :::
 
-@[code lang=java transcludeWith=:::1](@/reference/latest/src/client/java/com/example/docs/rendering/RenderingConceptsEntrypoint.java)
+**Element registration:**
+
+@[code lang=java transcludeWith=:::registration](@/reference/latest/src/client/java/com/example/docs/rendering/RenderingConceptsEntrypoint.java)
+
+**Implementation of `hudLayer()`:**
+
+@[code lang=java transcludeWith=:::hudLayer](@/reference/latest/src/client/java/com/example/docs/rendering/RenderingConceptsEntrypoint.java)
 
 This results in the following being drawn on the HUD:
 
@@ -190,3 +196,5 @@ Let's say we want to rotate our square around the z-axis. We can do this by usin
 The result of this is the following:
 
 ![A video showing the diamond rotating around the z-axis](/assets/develop/rendering/concepts-quaternions.webp)
+
+asssssss

--- a/develop/rendering/basic-concepts.md
+++ b/develop/rendering/basic-concepts.md
@@ -196,5 +196,3 @@ Let's say we want to rotate our square around the z-axis. We can do this by usin
 The result of this is the following:
 
 ![A video showing the diamond rotating around the z-axis](/assets/develop/rendering/concepts-quaternions.webp)
-
-asssssss

--- a/reference/latest/src/client/java/com/example/docs/rendering/RenderingConceptsEntrypoint.java
+++ b/reference/latest/src/client/java/com/example/docs/rendering/RenderingConceptsEntrypoint.java
@@ -17,18 +17,21 @@ public class RenderingConceptsEntrypoint implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
 		// "A Practical Example: Rendering a Triangle Strip"
-		// :::1
+		// :::registration
 		HudElementRegistry.addLast(ResourceLocation.fromNamespaceAndPath(ExampleMod.MOD_ID, "last_element"), hudLayer());
-		// :::1
+		// :::registration
 	}
 
+	// :::hudLayer
 	private HudElement hudLayer() {
 		return (drawContext, tickCounter) -> {
-			// :::1
+			// :::hudLayer
+
 			if (false) {
 				return;
 			}
 
+			// :::hudLayer
 			// :::2
 			Matrix3x2fStack matrices = drawContext.pose();
 
@@ -56,18 +59,17 @@ public class RenderingConceptsEntrypoint implements ClientModInitializer {
 			// Shift entire square so that it rotates in its center.
 			matrices.translate(-20f, -40f);
 			// :::3
-
-			// :::1
+			// :::hudLayer
 			drawContext.fillGradient(5, 20, 35, 60, 0xFF414141, 0xFF000000);
-			// :::1
-			// :::2
 
+			// :::hudLayer
+			// :::2
 			// We do not need to manually write to the buffer. DrawContext methods write to GUI buffer in `GuiRenderer` at the end of preparation.
 
 			// Pop our matrix from the stack.
 			matrices.popMatrix();
 			// :::2
-			// :::1
 		};
 	}
+	// :::hudLayer
 }


### PR DESCRIPTION
A user pointed out that the transclusions in the Basic Rendering Concepts is broken.

I've attempted to fix it by:
* Transcluding the registration line separately.
* Transcluding the method definition separately.

Other than a couple of empty lines moving, there should be no effect to other transcludes in the page.