### PR TITLE
Finish migrating "Creating Commands" page from Yarn names to Mojang Mappings.

### DIFF
--- a/develop/commands/basics.md
+++ b/develop/commands/basics.md
@@ -7,6 +7,7 @@ authors:
   - haykam821
   - i509VCB
   - Juuxel
+  - MildestToucan
   - modmuss50
   - mschae23
   - natanfudge
@@ -15,7 +16,6 @@ authors:
   - Technici4n
   - Treeways
   - xpple
-  - MildestToucan
 ---
 
 Creating commands can allow a mod developer to add functionality that can be used through a command. This tutorial will

--- a/develop/commands/basics.md
+++ b/develop/commands/basics.md
@@ -34,7 +34,7 @@ Brigadier is open-source: <https://github.com/Mojang/brigadier>
 `CommandSyntaxException` in certain cases. It has a generic type `S`, which defines the type of the _command source_.
 The command
 source provides some context in which a command was run. In Minecraft, the command source is typically a
-`ServerCommandSource` which can represent a server, a command block, a remote connection (RCON), a player or an entity.
+`CommandSourceStack` which can represent a server, a command block, a remote connection (RCON), a player or an entity.
 
 The single method in `Command`, `run(CommandContext<S>)` takes a `CommandContext<S>` as the sole parameter and returns
 an integer. The command context holds your command source of `S` and allows you to obtain arguments, look at the parsed
@@ -43,7 +43,7 @@ command nodes and see the input used in this command.
 Like other functional interfaces, it is usually used as a lambda or a method reference:
 
 ```java
-Command<ServerCommandSource> command = context -> {
+Command<CommandSourceStack> command = context -> {
     return 0;
 };
 ```
@@ -52,9 +52,9 @@ The integer can be considered the result of the command. Typically values less t
 do nothing. Positive values mean the command was successful and did something. Brigadier provides a constant to indicate
 success; `Command#SINGLE_SUCCESS`.
 
-### What Can the `ServerCommandSource` Do? {#what-can-the-servercommandsource-do}
+### What Can the `CommandSourceStack` Do? {#what-can-the-servercommandsource-do}
 
-A `ServerCommandSource` provides some additional implementation-specific context when a command is run. This includes
+A `CommandSourceStack` provides some additional implementation-specific context when a command is run. This includes
 the
 ability to get the entity that executed the command, the world the command was run in or the server the command was run
 on.
@@ -62,8 +62,8 @@ on.
 You can access the command source from a command context by calling `getSource()` on the `CommandContext` instance.
 
 ```java
-Command<ServerCommandSource> command = context -> {
-    ServerCommandSource source = context.getSource();
+Command<CommandSourceStack> command = context -> {
+    CommandSourceStack source = context.getSource();
     return 0;
 };
 ```
@@ -80,26 +80,26 @@ The event should be registered in your [mod's initializer](../getting-started/pr
 
 The callback has three parameters:
 
-- `CommandDispatcher<ServerCommandSource> dispatcher` - Used to register, parse and execute commands. `S` is the type
+- `CommandDispatcher<CommandSourceStack> dispatcher` - Used to register, parse and execute commands. `S` is the type
   of command source the command dispatcher supports.
-- `CommandRegistryAccess registryAccess` - Provides an abstraction to registries that may be passed to certain command
+- `CommandBuildContext registryAccess` - Provides an abstraction to registries that may be passed to certain command
   argument methods
-- `CommandManager.RegistrationEnvironment environment` - Identifies the type of server the commands are being registered
+- `Commands.CommandSelection environment` - Identifies the type of server the commands are being registered
   on.
 
 In the mod's initializer, we just register a simple command:
 
 @[code lang=java transcludeWith=:::test_command](@/reference/latest/src/main/java/com/example/docs/command/ExampleModCommands.java)
 
-In the `sendFeedback()` method, the first parameter is the text to be sent, which is a `Supplier<Text>` to avoid
-instantiating Text objects when not needed.
+In the `sendSuccess()` method, the first parameter is the text to be sent, which is a `Supplier<Component>` to avoid
+instantiating `Component` objects when not needed.
 
 The second parameter determines whether to broadcast the feedback to other
 operators. Generally, if the command is to query something without actually affecting the world, such as query the
 current time or some player's score, it should be `false`. If the command does something, such as changing the
 time or modifying someone's score, it should be `true`.
 
-If the command fails, instead of calling `sendFeedback()`, you may directly throw any exception and the server or client
+If the command fails, instead of calling `sendSuccess()`, you may directly throw any exception and the server or client
 will handle it appropriately.
 
 `CommandSyntaxException` is generally thrown to indicate syntax errors in commands or arguments. You can also implement
@@ -108,7 +108,7 @@ your own exception.
 To execute this command, you must type `/test_command`, which is case-sensitive.
 
 ::: info
-From this point onwards, we will be extracting the logic written within the lambda passed into `.execute()` builders into individual methods. We can then pass a method reference to `.execute()`. This is done for clarity.
+From this point onwards, we will be extracting the logic written within the lambda passed into `.executes()` builders into individual methods. We can then pass a method reference to `.executes()`. This is done for clarity.
 :::
 
 ### Registration Environment {#registration-environment}
@@ -122,7 +122,7 @@ the dedicated environment:
 ### Command Requirements {#command-requirements}
 
 Let's say you have a command that you only want operators to be able to execute. This is where the `requires()` method
-comes into play. The `requires()` method has one argument of a `Predicate<S>` which will supply a `ServerCommandSource`
+comes into play. The `requires()` method has one argument of a `Predicate<S>` which will supply a `CommandSourceStack`
 to test with and determine if the `CommandSource` can execute the command.
 
 @[code lang=java highlight={3} transcludeWith=:::required_command](@/reference/latest/src/main/java/com/example/docs/command/ExampleModCommands.java)
@@ -173,11 +173,11 @@ Brigadier [will only redirect command nodes with arguments](https://github.com/M
   Brigadier will handle the checked exceptions and forward the proper error message in the game for you.
 
 - Issues with generics - You may have an issue with generics once in a while. If you are registering server
-  commands (which are most of the case), make sure you are using `CommandManager.literal`
-  or `CommandManager.argument` instead of `LiteralArgumentBuilder.literal` or `RequiredArgumentBuilder.argument`.
+  commands (which are most of the case), make sure you are using `Commands.literal`
+  or `Commands.argument` instead of `LiteralArgumentBuilder.literal` or `RequiredArgumentBuilder.argument`.
 
-- Check `sendFeedback()` method - You may have forgotten to provide a boolean as the second argument. Also remember
-  that, since Minecraft 1.20, the first parameter is `Supplier<Text>` instead of `Text`.
+- Check the `sendSuccess()` method - You may have forgotten to provide a boolean as the second argument. Also remember
+  that, since Minecraft 1.20, the first parameter is `Supplier<Component>` instead of `Component`.
 
 - A Command should return an integer - When registering commands, the `executes()` method accepts a `Command` object,
   which is usually a lambda. The lambda should return an integer, instead of other types.
@@ -185,11 +185,11 @@ Brigadier [will only redirect command nodes with arguments](https://github.com/M
 ### Can I Register Commands at Runtime? {#can-i-register-commands-at-runtime}
 
 ::: warning
-You can do this, but it is not recommended. You would get the `CommandManager` from the server and add anything commands
+You can do this, but it is not recommended. You would get the `Commands` from the server and add anything commands
 you wish to its `CommandDispatcher`.
 
 After that, you need to send the command tree to every player again
-using `CommandManager.sendCommandTree(ServerPlayerEntity)`.
+using `Commands.sendCommands(ServerPlayer)`.
 
 This is required because the client locally caches the command tree it receives during login (or when operator packets
 are sent) for local completions-rich error messages.
@@ -202,7 +202,7 @@ You can also do this, however, it is much less stable than registering commands 
 effects.
 
 To keep things simple, you need to use reflection on Brigadier and remove nodes. After this, you need to send the
-command tree to every player again using `sendCommandTree(ServerPlayerEntity)`.
+command tree to every player again using `sendCommands(ServerPlayer)`.
 
 If you don't send the updated command tree, the client may think a command still exists, even though the server will
 fail execution.

--- a/develop/commands/basics.md
+++ b/develop/commands/basics.md
@@ -15,6 +15,7 @@ authors:
   - Technici4n
   - Treeways
   - xpple
+  - MildestToucan
 ---
 
 Creating commands can allow a mod developer to add functionality that can be used through a command. This tutorial will


### PR DESCRIPTION
Currently, there are several instances of the `Creating Commands` page, AKA `basics.md` under `Commands` in the repo, which still use Yarn names outside of code blocks.

This PR aims to fix this issue. Reviews and feedback are welcome.