### PR TITLE
Add porting guides

### DIFF
--- a/versions/1.21.1/develop/porting/current.md
+++ b/versions/1.21.1/develop/porting/current.md
@@ -1,0 +1,38 @@
+---
+title: Porting to 1.21.1
+description: A guide for porting to the 1.21.1 version of Minecraft.
+authors:
+  - cassiancc
+---
+
+Minecraft is a game that's constantly evolving, with new versions changing the game in ways that affect modders. This article covers the general steps one might follow to update their mod to the 1.21.1 update of Minecraft.
+
+1.21.1 is a hotfix for 1.21, so these docs will focus on 1.21.1 rather than 1.21, as there is no reason to continue to support a version with critical issues. Most 1.21 mods should work on 1.21.1.
+
+::: info
+These docs discuss migrating from **1.20.4** to **1.21.1**. If you're looking for another migration, switch to the target version by using the dropdown in the top-right corner.
+:::
+
+## Updating the Build Script {#build-script}
+
+Start by updating your mod's `gradle/wrapper/gradle-wrapper.properties`, `gradle.properties`, and `build.gradle` to the latest versions:
+
+1. Update Gradle to the latest version by running the following command: `./gradlew wrapper --gradle-version latest`
+2. Bump Minecraft, Fabric Loader, Fabric Loom and Fabric API, either in `gradle.properties` (recommended) or in `build.gradle`. Find the recommended versions of the Fabric components on the [Fabric Develop site](https://fabricmc.net/develop/).
+3. Refresh Gradle by using the refresh button in the top-right corner of IntelliJ IDEA. If this button is not visible, you can force caches to be cleared by running `./gradlew --refresh-dependencies`.
+
+## Updating the Code {#porting-guides}
+
+After the build script has been updated to 1.21.1, you can now go through your mod and update any code that has changed to make it compatible with the new version.
+
+To help you with updating, modders will document the changes they came across in articles, like the Fabric Blog, and NeoForge's porting primers.
+
+- [_Fabric for Minecraft 1.21 & 1.21.1_ on the Fabric blog](https://fabricmc.net/2024/05/31/121.html) contains a high-level explanation of the changes made to Fabric API in 1.21 and 1.21.1.
+- [_Minecraft: Java Edition 1.21_ on the Minecraft blog](https://www.minecraft.net/en-us/article/minecraft-java-edition-1-21-1) is the official overview of the features introduced in 1.21.1.
+  - [_Minecraft: Java Edition 1.21.1_ on the Minecraft blog](https://www.minecraft.net/en-us/article/minecraft-java-edition-1-21-1) is the official overview of the features introduced in 1.21.1.
+- [_Java Edition 1.21_ on the Minecraft Wiki](https://minecraft.wiki/w/Java_Edition_1.21.1) is an unofficial summary of the contents of the update.
+  - [_Java Edition 1.21.1_ on the Minecraft Wiki](https://minecraft.wiki/w/Java_Edition_1.21.1) is an unofficial summary of the contents of the update.
+- [slicedlime's Data Pack News in Minecraft 1.21](https://www.youtube.com/watch?v=x1rT4o7Q1dY) covers information relevant to updating your mod's data pack driven content.
+- [NeoForge's _Minecraft 1.20.6 -> 1.21 Mod Migration Primer_](https://github.com/neoforged/.github/blob/main/primers/1.21/index.md) covers migrating from 1.20.6 to 1.21, focusing only on vanilla code changes.
+  - [NeoForge's _Minecraft 1.21 -> 1.21.1 Mod Migration Primer_](https://github.com/neoforged/.github/blob/main/primers/1.21.1/index.md) covers migrating from 1.21.7 to 1.21.8, focusing only on vanilla code changes.
+  - Please note that these linked articles are third-party material, not maintained by Fabric. They are under copyright of @ChampionAsh5357, and licensed under [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/).

--- a/versions/1.21.10/develop/porting/current.md
+++ b/versions/1.21.10/develop/porting/current.md
@@ -1,0 +1,38 @@
+---
+title: Porting to 1.21.10
+description: A guide for porting to the 1.21.10 version of Minecraft.
+authors:
+  - cassiancc
+---
+
+Minecraft is a game that's constantly evolving, with new versions changing the game in ways that affect modders. This article covers the general steps one might follow to update their mod to the 1.21.10 update of Minecraft.
+
+1.21.10 is a hotfix for 1.21.9, so these docs will focus on 1.21.10 rather than 1.21.9, as there is no reason to continue to support a version with critical issues. Most 1.21.9 mods should work on 1.21.10.
+
+::: info
+These docs discuss migrating from **1.21.8** to **1.21.10**. If you're looking for another migration, switch to the target version by using the dropdown in the top-right corner.
+:::
+
+## Updating the Build Script {#build-script}
+
+Start by updating your mod's `gradle/wrapper/gradle-wrapper.properties`, `gradle.properties`, and `build.gradle` to the latest versions:
+
+1. Update Gradle to the latest version by running the following command: `./gradlew wrapper --gradle-version latest`
+2. Bump Minecraft, Fabric Loader, Fabric Loom and Fabric API, either in `gradle.properties` (recommended) or in `build.gradle`. Find the recommended versions of the Fabric components on the [Fabric Develop site](https://fabricmc.net/develop/).
+3. Refresh Gradle by using the refresh button in the top-right corner of IntelliJ IDEA. If this button is not visible, you can force caches to be cleared by running `./gradlew --refresh-dependencies`.
+
+## Updating the Code {#porting-guides}
+
+After the build script has been updated to 1.21.10, you can now go through your mod and update any code that has changed to make it compatible with the new version.
+
+To help you with updating, modders will document the changes they came across in articles, like the Fabric Blog, and NeoForge's porting primers.
+
+- [_Fabric for Minecraft 1.21.9 and 1.21.10_ on the Fabric blog](https://fabricmc.net/2025/09/23/1219.html) contains a high-level explanation of the changes made to Fabric API in 1.21.9 and 1.21.10.
+- [_Minecraft: Java Edition 1.21.9_ on the Minecraft blog](https://www.minecraft.net/en-us/article/minecraft-java-edition-1-21-9) is the official overview of the features introduced in 1.21.9.
+  - [_Minecraft: Java Edition 1.21.10_ on the Minecraft blog](https://www.minecraft.net/en-us/article/minecraft-java-edition-1-21-10) is the official overview of the features introduced in 1.21.10.
+- [_Java Edition 1.21.9_ on the Minecraft Wiki](https://minecraft.wiki/w/Java_Edition_1.21.9) is an unofficial summary of the contents of the update.
+  - [_Java Edition 1.21.10_ on the Minecraft Wiki](https://minecraft.wiki/w/Java_Edition_1.21.10) is an unofficial summary of the contents of the update.
+- [slicedlime's Data & Resource Pack News in Minecraft 1.21.9](https://www.youtube.com/watch?v=jcE-KOlGh_I) covers information relevant to updating your mod's data and resource pack driven content.
+- [NeoForge's _Minecraft 1.21.8 -> 1.21.9 Mod Migration Primer_](https://github.com/neoforged/.github/blob/main/primers/1.21.9/index.md) covers migrating from 1.21.8 to 1.21.9, focusing only on vanilla code changes.
+  - [NeoForge's _Minecraft 1.21.9 -> 1.21.10 Mod Migration Primer_](https://github.com/neoforged/.github/blob/main/primers/1.21.10/index.md) covers migrating from 1.21.9 to 1.21.10, focusing only on vanilla code changes.
+  - Please note that these linked articles are third-party material, not maintained by Fabric. They are under copyright of @ChampionAsh5357, and licensed under [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/).

--- a/versions/1.21.4/develop/porting/current.md
+++ b/versions/1.21.4/develop/porting/current.md
@@ -1,0 +1,33 @@
+---
+title: Porting to 1.21.4
+description: A guide for porting to the 1.21.4 version of Minecraft.
+authors:
+  - cassiancc
+---
+
+Minecraft is a game that's constantly evolving, with new versions changing the game in ways that affect modders. This article covers the general steps one might follow to update their mod to the 1.21.4 update of Minecraft.
+
+::: info
+These docs discuss migrating from **1.21.1** to **1.21.4**. If you're looking for another migration, switch to the target version by using the dropdown in the top-right corner.
+:::
+
+## Updating the Build Script {#build-script}
+
+Start by updating your mod's `gradle/wrapper/gradle-wrapper.properties`, `gradle.properties`, and `build.gradle` to the latest versions:
+
+1. Update Gradle to the latest version by running the following command: `./gradlew wrapper --gradle-version latest`
+2. Bump Minecraft, Fabric Loader, Fabric Loom and Fabric API, either in `gradle.properties` (recommended) or in `build.gradle`. Find the recommended versions of the Fabric components on the [Fabric Develop site](https://fabricmc.net/develop/).
+3. Refresh Gradle by using the refresh button in the top-right corner of IntelliJ IDEA. If this button is not visible, you can force caches to be cleared by running `./gradlew --refresh-dependencies`.
+
+## Updating the Code {#porting-guides}
+
+After the build script has been updated to 1.21.4, you can now go through your mod and update any code that has changed to make it compatible with the new version.
+
+To help you with updating, modders will document the changes they came across in articles, like the Fabric Blog, and NeoForge's porting primers.
+
+- [_Fabric for Minecraft 1.21.4_ on the Fabric blog](https://fabricmc.net/2024/12/02/1214.html) contains a high-level explanation of the changes made to Fabric API in 1.21.4.
+- [_Minecraft: Java Edition 1.21.4_ on the Minecraft blog](https://www.minecraft.net/en-us/article/minecraft-java-edition-1-21-4) is the official overview of the features introduced in 1.21.4.
+- [_Java Edition 1.21.4_ on the Minecraft Wiki](https://minecraft.wiki/w/Java_Edition_1.21.4) is an unofficial summary of the contents of the update.
+- [slicedlime's Data & Resource Pack News in Minecraft 1.21.4](https://www.youtube.com/watch?v=6K1QzvJx1IE) covers information relevant to updating your mod's data and resource pack driven content.
+- [NeoForge's _Minecraft 1.21.3 -> 1.21.4 Mod Migration Primer_](https://github.com/neoforged/.github/blob/main/primers/1.21.4/index.md) covers migrating from 1.21.3 to 1.21.4, focusing only on vanilla code changes.
+  - Please note that the linked article is third-party material, not maintained by Fabric. It's under copyright of @ChampionAsh5357, and licensed under [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/).

--- a/versions/1.21.8/develop/porting/current.md
+++ b/versions/1.21.8/develop/porting/current.md
@@ -1,0 +1,41 @@
+---
+title: Porting to 1.21.8
+description: A guide for porting to the 1.21.8 version of Minecraft.
+authors:
+  - cassiancc
+---
+
+Minecraft is a game that's constantly evolving, with new versions changing the game in ways that affect modders. This article covers the general steps one might follow to update their mod to the 1.21.8 update of Minecraft.
+
+1.21.8 is a hotfix for 1.21.7 and 1.21.6, so these docs will focus on 1.21.8 rather than 1.21.7 or 1.21.6, as there is no reason to continue to support a version with critical issues. Most 1.21.7 mods should work on 1.21.8.
+
+::: info
+These docs discuss migrating from **1.21.4** to **1.21.8**. If you're looking for another migration, switch to the target version by using the dropdown in the top-right corner.
+:::
+
+## Updating the Build Script {#build-script}
+
+Start by updating your mod's `gradle/wrapper/gradle-wrapper.properties`, `gradle.properties`, and `build.gradle` to the latest versions:
+
+1. Update Gradle to the latest version by running the following command: `./gradlew wrapper --gradle-version latest`
+2. Bump Minecraft, Fabric Loader, Fabric Loom and Fabric API, either in `gradle.properties` (recommended) or in `build.gradle`. Find the recommended versions of the Fabric components on the [Fabric Develop site](https://fabricmc.net/develop/).
+3. Refresh Gradle by using the refresh button in the top-right corner of IntelliJ IDEA. If this button is not visible, you can force caches to be cleared by running `./gradlew --refresh-dependencies`.
+
+## Updating the Code {#porting-guides}
+
+After the build script has been updated to 1.21.8, you can now go through your mod and update any code that has changed to make it compatible with the new version.
+
+To help you with updating, modders will document the changes they came across in articles, like the Fabric Blog, and NeoForge's porting primers.
+
+- [_Fabric for Minecraft 1.21.6, 1.21.7, and 1.21.8_ on the Fabric blog](https://fabricmc.net/2025/06/15/1216.html) contains a high-level explanation of the changes made to Fabric API in 1.21.6, 1.21.7 and 1.21.8.
+- [_Minecraft: Java Edition 1.21.6_ on the Minecraft blog](https://www.minecraft.net/en-us/article/minecraft-java-edition-1-21-6) is the official overview of the features introduced in 1.21.6.
+  - [_Minecraft: Java Edition 1.21.7_ on the Minecraft blog](https://www.minecraft.net/en-us/article/minecraft-java-edition-1-21-7) is the official overview of the features introduced in 1.21.7.
+  - [_Minecraft: Java Edition 1.21.8_ on the Minecraft blog](https://www.minecraft.net/en-us/article/minecraft-java-edition-1-21-7) is the official overview of the features introduced in 1.21.8.
+- [_Java Edition 1.21.6_ on the Minecraft Wiki](https://minecraft.wiki/w/Java_Edition_1.21.6) is an unofficial summary of the contents of the update.
+  - [_Java Edition 1.21.7_ on the Minecraft Wiki](https://minecraft.wiki/w/Java_Edition_1.21.7) is an unofficial summary of the contents of the update.
+  - [_Java Edition 1.21.8_ on the Minecraft Wiki](https://minecraft.wiki/w/Java_Edition_1.21.8) is an unofficial summary of the contents of the update.
+- [slicedlime's Data & Resource Pack News in Minecraft 1.21.6](https://www.youtube.com/watch?v=bRuoC0qUb5Y) covers information relevant to updating your mod's data and resource pack driven content.
+- [NeoForge's _Minecraft 1.21.5 -> 1.21.6 Mod Migration Primer_](https://github.com/neoforged/.github/blob/main/primers/1.21.6/index.md) covers migrating from 1.21.5 to 1.21.6, focusing only on vanilla code changes.
+  - [NeoForge's _Minecraft 1.21.6 -> 1.21.7 Mod Migration Primer_](https://github.com/neoforged/.github/blob/main/primers/1.21.7/index.md) covers migrating from 1.21.6 to 1.21.7, focusing only on vanilla code changes.
+  - [NeoForge's _Minecraft 1.21.7 -> 1.21.8 Mod Migration Primer_](https://github.com/neoforged/.github/blob/main/primers/1.21.8/index.md) covers migrating from 1.21.7 to 1.21.8, focusing only on vanilla code changes.
+  - Please note that these linked articles are third-party material, not maintained by Fabric. They are under copyright of @ChampionAsh5357, and licensed under [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/).


### PR DESCRIPTION
Adds porting guides in the same style as the new 1.21.11 porting guide, accessible via the version switcher on the 1.21.11+ article.