### PR TITLE
Fixes for migrate mappings pages

### DIFF
--- a/develop/migrating-mappings/loom.md
+++ b/develop/migrating-mappings/loom.md
@@ -24,25 +24,25 @@ For best results, it's recommended to update to Loom 1.13 or above, as it allows
 
 ## Migrating to Mojang Mappings {#migrating-to-mojmap}
 
-First, you need to run a `migrateMappings` command that will migrate your current mappings to Mojang Mappings. For example, the following command would migrate to Mojang Mappings for 1.21.10:
+First, you need to run a `migrateMappings` command that will migrate your current mappings to Mojang Mappings. For example, the following command would migrate to Mojang Mappings for 1.21.11:
 
 ::: code-group
 
 ```powershell:no-line-numbers [Windows]
-./gradlew.bat migrateMappings --mappings "net.minecraft:mappings:1.21.10"
+./gradlew.bat migrateMappings --mappings "net.minecraft:mappings:1.21.11"
 ```
 
 ```sh:no-line-numbers [macOS/Linux]
-./gradlew migrateMappings --mappings "net.minecraft:mappings:1.21.10"
+./gradlew migrateMappings --mappings "net.minecraft:mappings:1.21.11"
 ```
 
 ```sh:no-line-numbers [IntelliJ]
-migrateMappings --mappings "net.minecraft:mappings:1.21.10"
+migrateMappings --mappings "net.minecraft:mappings:1.21.11"
 ```
 
 :::
 
-You can replace `1.21.10` with the version of Minecraft you are migrating from. This must be the same version of Minecraft you are currently running. **Do not modify your `gradle.properties` or `build.gradle` yet!**
+You can replace `1.21.11` with the version of Minecraft you are migrating from. This must be the same version of Minecraft you are currently running. **Do not modify your `gradle.properties` or `build.gradle` yet!**
 
 ### Editing Your Sources {#editing-sources-mojmap}
 
@@ -53,15 +53,15 @@ If you are using Loom 1.13 or above, you can use the program argument `--overrid
 ::: code-group
 
 ```powershell:no-line-numbers [Windows]
-./gradlew.bat migrateMappings --mappings "net.minecraft:mappings:1.21.10" --overrideInputsIHaveABackup
+./gradlew.bat migrateMappings --mappings "net.minecraft:mappings:1.21.11" --overrideInputsIHaveABackup
 ```
 
 ```sh:no-line-numbers [macOS/Linux]
-./gradlew migrateMappings --mappings "net.minecraft:mappings:1.21.10" --overrideInputsIHaveABackup
+./gradlew migrateMappings --mappings "net.minecraft:mappings:1.21.11" --overrideInputsIHaveABackup
 ```
 
 ```sh:no-line-numbers [IntelliJ]
-migrateMappings --mappings "net.minecraft:mappings:1.21.10" --overrideInputsIHaveABackup
+migrateMappings --mappings "net.minecraft:mappings:1.21.11" --overrideInputsIHaveABackup
 ```
 
 :::
@@ -73,7 +73,7 @@ If you are coming from Yarn, you can now replace your mappings in your `build.gr
 ```groovy
 dependencies {
     [...]
-    mappings "net.fabricmc:yarn${project.yarn_mappings}:v2" // [!code --]
+    mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2" // [!code --]
     mappings loom.officialMojangMappings() // [!code ++]
 }
 ```
@@ -88,25 +88,29 @@ Tools like [mappings.dev](https://mappings.dev/) or [Linkie](https://linkie.shed
 
 ## Migrating to Yarn {#migrating-to-yarn}
 
+::: warning
+1.21.11 is the final release where Yarn Mappings will be available. If you plan to update your mod to 26.1 or above, your mod should be on Mojang's Mappings.
+:::
+
 First, you need to run a `migrateMappings` command that will convert your current mappings to Yarn Mappings. This can be found on [the Develop site](https://fabricmc.net/develop) under Mappings Migration. For example:
 
 ::: code-group
 
 ```powershell:no-line-numbers [Windows]
-./gradlew.bat migrateMappings --mappings "1.21.10+build.2"
+./gradlew.bat migrateMappings --mappings "1.21.11+build.3"
 ```
 
 ```sh:no-line-numbers [macOS/Linux]
-./gradlew migrateMappings --mappings "1.21.10+build.2"
+./gradlew migrateMappings --mappings "1.21.11+build.3"
 ```
 
 ```sh:no-line-numbers [IntelliJ]
-migrateMappings --mappings "1.21.10+build.2"
+migrateMappings --mappings "1.21.11+build.3"
 ```
 
 :::
 
-You can replace `1.21.10` with the version of Minecraft you are migrating from. This must be the same version of Minecraft you are currently running. **Do not modify your `gradle.properties` or `build.gradle` yet!**
+You can replace `1.21.11` with the version of Minecraft you are migrating from. This must be the same version of Minecraft you are currently running. **Do not modify your `gradle.properties` or `build.gradle` yet!**
 
 ### Editing Your Sources {#editing-sources-yarn}
 
@@ -117,15 +121,15 @@ If you are using Loom 1.13 or above, you can use the program argument `--overrid
 ::: code-group
 
 ```powershell:no-line-numbers [Windows]
-./gradlew.bat migrateMappings --mappings "1.21.10+build.2" --overrideInputsIHaveABackup
+./gradlew.bat migrateMappings --mappings "1.21.11+build.3" --overrideInputsIHaveABackup
 ```
 
 ```sh:no-line-numbers [macOS/Linux]
-./gradlew migrateMappings --mappings "1.21.10+build.2" --overrideInputsIHaveABackup
+./gradlew migrateMappings --mappings "1.21.11+build.3" --overrideInputsIHaveABackup
 ```
 
 ```sh:no-line-numbers [IntelliJ]
-migrateMappings --mappings "1.21.10+build.2" --overrideInputsIHaveABackup
+migrateMappings --mappings "1.21.11+build.3" --overrideInputsIHaveABackup
 ```
 
 :::
@@ -137,7 +141,7 @@ If you are migrating from Mojang Mappings, you can now replace your mappings in 
 **`gradle.properties`**
 
 ```properties
-yarn_mappings=1.21.10+build.2
+yarn_mappings=1.21.11+build.3
 ```
 
 **`build.gradle`**
@@ -146,7 +150,7 @@ yarn_mappings=1.21.10+build.2
 dependencies {
     [...]
     mappings loom.officialMojangMappings() // [!code --]
-    mappings "net.fabricmc:yarn${project.yarn_mappings}:v2" // [!code ++]
+    mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2" // [!code ++]
 }
 ```
 
@@ -167,15 +171,15 @@ Loom 1.13 adds a new `migrateClientMappings` task that can be used to migrate yo
 ::: code-group
 
 ```powershell:no-line-numbers [Windows]
-./gradlew.bat migrateClientMappings --mappings "net.minecraft:mappings:1.21.10"
+./gradlew.bat migrateClientMappings --mappings "net.minecraft:mappings:1.21.11"
 ```
 
 ```sh:no-line-numbers [macOS/Linux]
-./gradlew migrateClientMappings --mappings "net.minecraft:mappings:1.21.10"
+./gradlew migrateClientMappings --mappings "net.minecraft:mappings:1.21.11"
 ```
 
 ```sh:no-line-numbers [IntelliJ]
-migrateClientMappings --mappings "net.minecraft:mappings:1.21.10"
+migrateClientMappings --mappings "net.minecraft:mappings:1.21.11"
 ```
 
 :::
@@ -189,15 +193,15 @@ Loom 1.13 adds a new `migrateClassTweakerMappings` task that can be used to migr
 ::: code-group
 
 ```powershell:no-line-numbers [Windows]
-./gradlew.bat migrateClassTweakerMappings --mappings "net.minecraft:mappings:1.21.10"
+./gradlew.bat migrateClassTweakerMappings --mappings "net.minecraft:mappings:1.21.11"
 ```
 
 ```sh:no-line-numbers [macOS/Linux]
-./gradlew migrateClassTweakerMappings --mappings "net.minecraft:mappings:1.21.10"
+./gradlew migrateClassTweakerMappings --mappings "net.minecraft:mappings:1.21.11"
 ```
 
 ```sh:no-line-numbers [IntelliJ]
-migrateClassTweakerMappings --mappings "net.minecraft:mappings:1.21.10"
+migrateClassTweakerMappings --mappings "net.minecraft:mappings:1.21.11"
 ```
 
 :::
@@ -213,15 +217,15 @@ For example, to migrate a client source set to Mojang Mappings in-place (overwri
 ::: code-group
 
 ```powershell:no-line-numbers [Windows]
-./gradlew.bat migrateMappings --input "src/client/java" --output "src/client/java" --mappings "net.minecraft:mappings:1.21.10"
+./gradlew.bat migrateMappings --input "src/client/java" --output "src/client/java" --mappings "net.minecraft:mappings:1.21.11"
 ```
 
 ```sh:no-line-numbers [macOS/Linux]
-./gradlew migrateMappings --input "src/client/java" --output "src/client/java" --mappings "net.minecraft:mappings:1.21.10"
+./gradlew migrateMappings --input "src/client/java" --output "src/client/java" --mappings "net.minecraft:mappings:1.21.11"
 ```
 
 ```sh:no-line-numbers [IntelliJ]
-migrateMappings --input "src/client/java" --output "src/client/java" --mappings "net.minecraft:mappings:1.21.10"
+migrateMappings --input "src/client/java" --output "src/client/java" --mappings "net.minecraft:mappings:1.21.11"
 ```
 
 :::

--- a/develop/migrating-mappings/ravel.md
+++ b/develop/migrating-mappings/ravel.md
@@ -18,20 +18,7 @@ Install it from [JetBrains Marketplace](https://plugins.jetbrains.com/plugin/289
 Commit any changes before attempting to remap your sources!
 :::
 
-### Prerequisites {#prerequisites}
-
-::: info
-Ravel 0.3+ now includes downloader for Yarn and Mojang Mappings, so you can skip this section.
-:::
-
-First, you need to get your mappings. For remapping from Yarn to Mojang Mappings or vice versa, you need to download both of them.
-
-- [Find and download Yarn mappings](https://maven.fabricmc.net/net/fabricmc/yarn/), choose the `mergedv2.jar`, extract it as a ZIP. The mappings is in `mappings/mappings.tiny` file.
-- Download Mojang mappings by [searching for your Minecraft version](https://piston-meta.mojang.com/mc/game/version_manifest_v2.json), open the JSON url, search for `client_mappings`, and download the `client.txt`
-
-### Remapping {#remapping}
-
-Next, right click on a file open in the Editor and choose **Refactor** > **Remap Using Ravel**
+Start by right clicking on a file open in the Editor and choose **Refactor** > **Remap Using Ravel**
 
 ![Right Click Menu](/assets/develop/misc/migrating-mappings/ravel_right_click.png)
 
@@ -40,6 +27,10 @@ A dialog like this will open. You can also open the dialog by clicking **Refacto
 ![Ravel Dialog](/assets/develop/misc/migrating-mappings/ravel_dialog.png)
 
 Next, add the mappings by clicking the + icon. Click the download option if you don't have them already.
+
+::: info
+If you do not see the download button, update Ravel to 0.3 or above.
+:::
 
 - For migrating from Yarn to Mojang Mappings, add the Yarn `mappings.tiny` file first, choose `named` as the **source** namespace and `official` as the **destination** namespace. Then, add the Mojang `client.txt` file and choose `target` as the **source** namespace and `source` as the **destination** namespace.
 - For migrating from Mojang Mappings to Yarn, add the Mojang `client.txt` first, this time choosing `source` as the **source** and `target` as the **destination**. Then, add the Yarn `mappings.tiny` and choose `official` as the **source** and `named` as the **destination**.
@@ -54,7 +45,7 @@ After the remapping finished, replace your mappings in your mod's `build.gradle`
 
 ```groovy
 dependencies {
-    mappings "net.fabricmc:yarn${project.yarn_mappings}:v2" // [!code --]
+    mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2" // [!code --]
     mappings loom.officialMojangMappings() // [!code ++]
     // Or the reverse if you're migrating from Mojang Mappings to Yarn
 }
@@ -63,7 +54,7 @@ dependencies {
 Also update your `gradle.properties`, remove `yarn_mappings` option or update it to the one you use.
 
 ```properties
-yarn_mappings=1.21.10+build.2 # [!code --]
+yarn_mappings=1.21.11+build.3 # [!code --]
 ```
 
 ### Final Changes {#final-changes}
@@ -74,4 +65,4 @@ For problems that are detected by Ravel, you can search (Ctrl+Shift+F) for `TODO
 
 ![Ravel TODO Search](/assets/develop/misc/migrating-mappings/ravel_todo.png)
 
-Tools like [mappings.dev](https://mappings.dev/) or [Linkie](https://linkie.shedaniel.dev/mappings?namespace=yarn&translateMode=ns&translateAs=mojang_raw&search=&version=1.21.10) will be helpful to familiarize yourself with your new mappings.
+Tools like [mappings.dev](https://mappings.dev/) or [Linkie](https://linkie.shedaniel.dev/mappings?namespace=yarn&translateMode=ns&translateAs=mojang_raw&search=&version=1.21.11) will be helpful to familiarize yourself with your new mappings.

--- a/develop/migrating-mappings/ravel.md
+++ b/develop/migrating-mappings/ravel.md
@@ -6,7 +6,7 @@ authors:
   - deirn
 ---
 
-[Ravel](https://github.com/badasintended/ravel) is a plugin for IntelliJ IDEA to remap source files, based on [IntelliJ's PSI](https://plugins.jetbrains.com/docs/intellij/psi.html) and [Mapping-IO](https://github.com/FabricMC/mapping-io). It supports remapping Java, Kotlin, Mixins (written in Java), Class Tweaker, and Access Wideners.
+[Ravel](https://github.com/badasintended/ravel) is a plugin for IntelliJ IDEA to remap source files, based on [IntelliJ's PSI](https://plugins.jetbrains.com/docs/intellij/psi.html) and [Mapping-IO](https://github.com/FabricMC/mapping-io). It supports remapping Java, Kotlin, Mixins (written in Java), Class Tweakers, and Access Wideners.
 
 Install it from [JetBrains Marketplace](https://plugins.jetbrains.com/plugin/28938-ravel-remapper) or download the ZIP file from [GitHub Releases](https://github.com/badasintended/ravel/releases) and install it by clicking the gear icon on the plugin settings and clicking **Install Plugin From Disk**.
 
@@ -15,7 +15,7 @@ Install it from [JetBrains Marketplace](https://plugins.jetbrains.com/plugin/289
 ## Migrating Mappings {#migrating-mappings}
 
 ::: warning
-Commit any changes before attempting to remap your sources!
+Commit any changes before attempting to remap your sources! **Do not modify your `gradle.properties` or `build.gradle` yet!**
 :::
 
 Start by right clicking on a file open in the Editor and choose **Refactor** > **Remap Using Ravel**

--- a/versions/1.21.10/develop/migrating-mappings/loom.md
+++ b/versions/1.21.10/develop/migrating-mappings/loom.md
@@ -73,7 +73,7 @@ If you are coming from Yarn, you can now replace your mappings in your `build.gr
 ```groovy
 dependencies {
     [...]
-    mappings "net.fabricmc:yarn${project.yarn_mappings}:v2" // [!code --]
+    mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2" // [!code --]
     mappings loom.officialMojangMappings() // [!code ++]
 }
 ```
@@ -146,7 +146,7 @@ yarn_mappings=1.21.10+build.2
 dependencies {
     [...]
     mappings loom.officialMojangMappings() // [!code --]
-    mappings "net.fabricmc:yarn${project.yarn_mappings}:v2" // [!code ++]
+    mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2" // [!code ++]
 }
 ```
 

--- a/versions/1.21.10/develop/migrating-mappings/ravel.md
+++ b/versions/1.21.10/develop/migrating-mappings/ravel.md
@@ -54,7 +54,7 @@ After the remapping finished, replace your mappings in your mod's `build.gradle`
 
 ```groovy
 dependencies {
-    mappings "net.fabricmc:yarn${project.yarn_mappings}:v2" // [!code --]
+    mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2" // [!code --]
     mappings loom.officialMojangMappings() // [!code ++]
     // Or the reverse if you're migrating from Mojang Mappings to Yarn
 }


### PR DESCRIPTION
- Replaced 1.21.10 references with 1.21.11.
- Added a warning on Migrating to Yarn.
- Removed outdated Ravel information on downloading mappings.
- Fixed typo on Yarn `build.gradle` sections.