### PR TITLE
Windows users installing Java need to restart the OS

### DIFF
--- a/players/installing-java/windows.md
+++ b/players/installing-java/windows.md
@@ -55,6 +55,14 @@ Follow the steps in the installer to install Java 21. When you reach this page, 
 
 Once you've done that, you can click `Next` and continue with the installation.
 
+::: warning
+
+Windows won't always tell other programs that Java is installed until you restart your computer.
+
+**Make sure to restart your computer before continuing!**
+
+:::
+
 ## 4. Verify That Java 21 Is Installed {#4-verify-that-java-is-installed}
 
 Once the installation is complete, you can verify that Java 21 is installed by opening the command prompt again and typing `java -version`.

--- a/players/installing-java/windows.md
+++ b/players/installing-java/windows.md
@@ -3,6 +3,7 @@ title: Installing Java on Windows
 description: A step-by-step guide on how to install Java on Windows.
 authors:
   - IMB11
+  - skycatminepokie
 next: false
 ---
 


### PR DESCRIPTION
One of the more common issues in the Discord is players verifying they have Java installed on the command line, but the installer not picking up on that. I've noticed that many applications don't seem to notice when Java is installed until after a restart.

I added a callout instead of a step since a new header would break old links, but if it's preferred to add a new header (since people are more likely to read it), I can change it.