### PR TITLE
Remove event usage in custom item group guide

### DIFF
--- a/develop/blocks/first-block.md
+++ b/develop/blocks/first-block.md
@@ -2,6 +2,7 @@
 title: Creating Your First Block
 description: Learn how to create your first custom block in Minecraft.
 authors:
+  - CelDaemon
   - Earthcomputer
   - IMB11
   - its-miroma

--- a/develop/blocks/first-block.md
+++ b/develop/blocks/first-block.md
@@ -61,11 +61,11 @@ You can also use `BlockBehavior.Properties.ofFullCopy(BlockBehavior block)` to c
 
 To automatically create the block item, we can pass `true` to the `shouldRegisterItem` parameter of the `register` method we created in the previous step.
 
-### Adding Your Block's Item to an Item Group {#adding-your-block-s-item-to-an-item-group}
+### Adding Your Block's Item to a Creative Tab {#adding-your-block-s-item-to-a-creative-tab}
 
 Since the `BlockItem` is automatically created and registered, to add it to an item group, you must use the `Block.asItem()` method to get the `BlockItem` instance.
 
-For this example, we'll use a custom item group created in the [Custom Item Groups](../items/custom-item-groups) page.
+For this example, we will add the block to the `BUILDING_BLOCKS` tab. To instead add the block to a custom creative tab, see [Custom Creative Tabs](../items/custom-item-groups).
 
 @[code transcludeWith=:::6](@/reference/latest/src/main/java/com/example/docs/block/ModBlocks.java)
 

--- a/develop/items/custom-item-groups.md
+++ b/develop/items/custom-item-groups.md
@@ -10,7 +10,7 @@ Creative Tabs, also known as Item Groups, are the tabs in the creative inventory
 
 ## Creating the Creative Tab {#creating-the-creative-tab}
 
-Adding a creative tab is pretty simple. Simply create a new static final field in your items class to store the creative tab and a resource key for it. You can then use Fabric's `FabricItemGroup.builder` to create the tab and add items to it:
+Adding a creative tab is pretty simple. Simply create a new static final field in your items class to store the creative tab and a resource key for it. You can then use `FabricItemGroup.builder` to create the tab and add items to it:
 
 @[code transcludeWith=:::9](@/reference/latest/src/main/java/com/example/docs/item/ModItems.java)
 

--- a/develop/items/custom-item-groups.md
+++ b/develop/items/custom-item-groups.md
@@ -2,6 +2,7 @@
 title: Custom Creative Tabs
 description: Learn how to create your own creative tab and add items to it.
 authors:
+  - CelDaemon
   - IMB11
 ---
 

--- a/develop/items/custom-item-groups.md
+++ b/develop/items/custom-item-groups.md
@@ -9,7 +9,7 @@ Creative Tabs, also known as Item Groups, are the tabs in the creative inventory
 
 ## Creating the Creative Tab {#creating-the-creative-tab}
 
-Adding a creative tab is pretty simple. Simply create a new static final field in your items class to store the creative tab and a resource key for it, you can then use Fabric's `ItemGroupEvents.modifyEntriesEvent` similarly to how you added your items to the vanilla creative tabs:
+Adding a creative tab is pretty simple. Simply create a new static final field in your items class to store the creative tab and a resource key for it. You can then use Fabric's `FabricItemGroup.builder` to create the tab and add items to it:
 
 @[code transcludeWith=:::9](@/reference/latest/src/main/java/com/example/docs/item/ModItems.java)
 

--- a/reference/latest/src/main/java/com/example/docs/block/ModBlocks.java
+++ b/reference/latest/src/main/java/com/example/docs/block/ModBlocks.java
@@ -9,6 +9,7 @@ import net.minecraft.data.BlockFamily;
 import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.CreativeModeTabs;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.DoorBlock;
@@ -28,7 +29,6 @@ import com.example.docs.block.custom.CounterBlock;
 import com.example.docs.block.custom.EngineBlock;
 import com.example.docs.block.custom.PrismarineLampBlock;
 import com.example.docs.block.custom.VerticalSlabBlock;
-import com.example.docs.item.ModItems;
 
 // :::1
 public class ModBlocks {
@@ -163,20 +163,6 @@ public class ModBlocks {
 			itemGroup.accept(ModBlocks.CONDENSED_DIRT.asItem());
 		});
 		// :::6
-
-		ItemGroupEvents.modifyEntriesEvent(ModItems.CUSTOM_ITEM_GROUP_KEY).register((itemGroup) -> {
-			itemGroup.accept(ModBlocks.CONDENSED_OAK_LOG.asItem());
-			itemGroup.accept(ModBlocks.PRISMARINE_LAMP.asItem());
-			itemGroup.accept(ModBlocks.COUNTER_BLOCK.asItem());
-			itemGroup.accept(ModBlocks.ENGINE_BLOCK.asItem());
-			itemGroup.accept(ModBlocks.RUBY_BLOCK.asItem());
-			itemGroup.accept(ModBlocks.RUBY_STAIRS.asItem());
-			itemGroup.accept(ModBlocks.RUBY_SLAB.asItem());
-			itemGroup.accept(ModBlocks.RUBY_FENCE.asItem());
-			itemGroup.accept(ModBlocks.RUBY_DOOR.asItem());
-			itemGroup.accept(ModBlocks.RUBY_TRAPDOOR.asItem());
-			itemGroup.accept(ModBlocks.VERTICAL_OAK_LOG_SLAB.asItem());
-		});
 	}
 
 	// :::1

--- a/reference/latest/src/main/java/com/example/docs/block/ModBlocks.java
+++ b/reference/latest/src/main/java/com/example/docs/block/ModBlocks.java
@@ -159,7 +159,7 @@ public class ModBlocks {
 
 	public static void setupItemGroups() {
 		// :::6
-		ItemGroupEvents.modifyEntriesEvent(ModItems.CUSTOM_ITEM_GROUP_KEY).register((itemGroup) -> {
+		ItemGroupEvents.modifyEntriesEvent(CreativeModeTabs.BUILDING_BLOCKS).register((itemGroup) -> {
 			itemGroup.accept(ModBlocks.CONDENSED_DIRT.asItem());
 		});
 		// :::6

--- a/reference/latest/src/main/java/com/example/docs/item/ModItems.java
+++ b/reference/latest/src/main/java/com/example/docs/item/ModItems.java
@@ -105,6 +105,17 @@ public class ModItems {
 	public static final CreativeModeTab CUSTOM_ITEM_GROUP = FabricItemGroup.builder()
 			.icon(() -> new ItemStack(ModItems.GUIDITE_SWORD))
 			.title(Component.translatable("itemGroup.example-mod"))
+			.displayItems((params, output) -> {
+					output.accept(ModItems.SUSPICIOUS_SUBSTANCE);
+					output.accept(ModItems.POISONOUS_APPLE);
+					output.accept(ModItems.GUIDITE_SWORD);
+					output.accept(ModItems.GUIDITE_HELMET);
+					output.accept(ModItems.GUIDITE_BOOTS);
+					output.accept(ModItems.GUIDITE_LEGGINGS);
+					output.accept(ModItems.GUIDITE_CHESTPLATE);
+					output.accept(ModItems.LIGHTNING_STICK);
+					// ...
+			})
 			.build();
 	// :::9
 	// :::5
@@ -206,19 +217,6 @@ public class ModItems {
 		// :::_12
 		// Register the group.
 		Registry.register(BuiltInRegistries.CREATIVE_MODE_TAB, CUSTOM_ITEM_GROUP_KEY, CUSTOM_ITEM_GROUP);
-
-		// Register items to the custom item group.
-		ItemGroupEvents.modifyEntriesEvent(CUSTOM_ITEM_GROUP_KEY).register(itemGroup -> {
-			itemGroup.accept(ModItems.SUSPICIOUS_SUBSTANCE);
-			itemGroup.accept(ModItems.POISONOUS_APPLE);
-			itemGroup.accept(ModItems.GUIDITE_SWORD);
-			itemGroup.accept(ModItems.GUIDITE_HELMET);
-			itemGroup.accept(ModItems.GUIDITE_BOOTS);
-			itemGroup.accept(ModItems.GUIDITE_LEGGINGS);
-			itemGroup.accept(ModItems.GUIDITE_CHESTPLATE);
-			itemGroup.accept(ModItems.LIGHTNING_STICK);
-			// ...
-		});
 		// :::_12
 
 		ItemGroupEvents.modifyEntriesEvent(CUSTOM_ITEM_GROUP_KEY).register(itemGroup -> {

--- a/reference/latest/src/main/java/com/example/docs/item/ModItems.java
+++ b/reference/latest/src/main/java/com/example/docs/item/ModItems.java
@@ -111,37 +111,37 @@ public class ModItems {
 			.icon(() -> new ItemStack(ModItems.GUIDITE_SWORD))
 			.title(Component.translatable("itemGroup.example-mod"))
 			.displayItems((params, output) -> {
-					output.accept(ModItems.SUSPICIOUS_SUBSTANCE);
-					output.accept(ModItems.POISONOUS_APPLE);
-					// :::9
-					output.accept(ModItems.GUIDITE_SWORD);
-					output.accept(ModItems.GUIDITE_HELMET);
-					output.accept(ModItems.GUIDITE_BOOTS);
-					output.accept(ModItems.GUIDITE_LEGGINGS);
-					output.accept(ModItems.GUIDITE_CHESTPLATE);
-					output.accept(ModItems.LIGHTNING_STICK);
-					// :::9
+				output.accept(ModItems.SUSPICIOUS_SUBSTANCE);
+				output.accept(ModItems.POISONOUS_APPLE);
+				// :::9
+				output.accept(ModItems.GUIDITE_SWORD);
+				output.accept(ModItems.GUIDITE_HELMET);
+				output.accept(ModItems.GUIDITE_BOOTS);
+				output.accept(ModItems.GUIDITE_LEGGINGS);
+				output.accept(ModItems.GUIDITE_CHESTPLATE);
+				output.accept(ModItems.LIGHTNING_STICK);
+				// :::9
 
-					// The tab builder also accepts Blocks
-					output.accept(ModBlocks.CONDENSED_OAK_LOG);
-					output.accept(ModBlocks.PRISMARINE_LAMP);
-					// :::9
-					output.accept(ModBlocks.COUNTER_BLOCK);
-					output.accept(ModBlocks.ENGINE_BLOCK);
-					output.accept(ModBlocks.RUBY_BLOCK);
-					output.accept(ModBlocks.RUBY_STAIRS);
-					output.accept(ModBlocks.RUBY_SLAB);
-					output.accept(ModBlocks.RUBY_FENCE);
-					output.accept(ModBlocks.RUBY_DOOR);
-					output.accept(ModBlocks.RUBY_TRAPDOOR);
-					output.accept(ModBlocks.VERTICAL_OAK_LOG_SLAB);
-					// :::9
+				// The tab builder also accepts Blocks
+				output.accept(ModBlocks.CONDENSED_OAK_LOG);
+				output.accept(ModBlocks.PRISMARINE_LAMP);
+				// :::9
+				output.accept(ModBlocks.COUNTER_BLOCK);
+				output.accept(ModBlocks.ENGINE_BLOCK);
+				output.accept(ModBlocks.RUBY_BLOCK);
+				output.accept(ModBlocks.RUBY_STAIRS);
+				output.accept(ModBlocks.RUBY_SLAB);
+				output.accept(ModBlocks.RUBY_FENCE);
+				output.accept(ModBlocks.RUBY_DOOR);
+				output.accept(ModBlocks.RUBY_TRAPDOOR);
+				output.accept(ModBlocks.VERTICAL_OAK_LOG_SLAB);
+				// :::9
 
-					// And custom ItemStacks
-					ItemStack stack = new ItemStack(Items.SEA_PICKLE);
-					stack.set(DataComponents.ITEM_NAME, Component.literal("Pickle Rick"));
-					stack.set(DataComponents.LORE, new ItemLore(List.of(Component.literal("I'm pickle riiick!!"))));
-					output.accept(stack);
+				// And custom ItemStacks
+				ItemStack stack = new ItemStack(Items.SEA_PICKLE);
+				stack.set(DataComponents.ITEM_NAME, Component.literal("Pickle Rick"));
+				stack.set(DataComponents.LORE, new ItemLore(List.of(Component.literal("I'm pickle riiick!!"))));
+				output.accept(stack);
 			})
 			.build();
 	// :::9

--- a/reference/latest/src/main/java/com/example/docs/item/ModItems.java
+++ b/reference/latest/src/main/java/com/example/docs/item/ModItems.java
@@ -1,8 +1,10 @@
 package com.example.docs.item;
 
+import java.util.List;
 import java.util.function.Function;
 
 import net.minecraft.core.Registry;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
@@ -22,10 +24,12 @@ import net.minecraft.world.item.CreativeModeTabs;
 import net.minecraft.world.item.HoeItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.item.SpawnEggItem;
 import net.minecraft.world.item.ToolMaterial;
 import net.minecraft.world.item.component.Consumable;
 import net.minecraft.world.item.component.Consumables;
+import net.minecraft.world.item.component.ItemLore;
 import net.minecraft.world.item.consume_effects.ApplyStatusEffectsConsumeEffect;
 import net.minecraft.world.item.equipment.ArmorType;
 import net.minecraft.world.level.Level;
@@ -36,6 +40,7 @@ import net.fabricmc.fabric.api.registry.CompostingChanceRegistry;
 import net.fabricmc.fabric.api.registry.FuelRegistryEvents;
 
 import com.example.docs.ExampleMod;
+import com.example.docs.block.ModBlocks;
 import com.example.docs.component.ModComponents;
 import com.example.docs.item.armor.GuiditeArmorMaterial;
 import com.example.docs.item.custom.CounterItem;
@@ -108,13 +113,35 @@ public class ModItems {
 			.displayItems((params, output) -> {
 					output.accept(ModItems.SUSPICIOUS_SUBSTANCE);
 					output.accept(ModItems.POISONOUS_APPLE);
+					// :::9
 					output.accept(ModItems.GUIDITE_SWORD);
 					output.accept(ModItems.GUIDITE_HELMET);
 					output.accept(ModItems.GUIDITE_BOOTS);
 					output.accept(ModItems.GUIDITE_LEGGINGS);
 					output.accept(ModItems.GUIDITE_CHESTPLATE);
 					output.accept(ModItems.LIGHTNING_STICK);
-					// ...
+					// :::9
+
+					// The tab builder also accepts Blocks
+					output.accept(ModBlocks.CONDENSED_OAK_LOG);
+					output.accept(ModBlocks.PRISMARINE_LAMP);
+					// :::9
+					output.accept(ModBlocks.COUNTER_BLOCK);
+					output.accept(ModBlocks.ENGINE_BLOCK);
+					output.accept(ModBlocks.RUBY_BLOCK);
+					output.accept(ModBlocks.RUBY_STAIRS);
+					output.accept(ModBlocks.RUBY_SLAB);
+					output.accept(ModBlocks.RUBY_FENCE);
+					output.accept(ModBlocks.RUBY_DOOR);
+					output.accept(ModBlocks.RUBY_TRAPDOOR);
+					output.accept(ModBlocks.VERTICAL_OAK_LOG_SLAB);
+					// :::9
+
+					// And custom ItemStacks
+					ItemStack stack = new ItemStack(Items.SEA_PICKLE);
+					stack.set(DataComponents.ITEM_NAME, Component.literal("Pickle Rick"));
+					stack.set(DataComponents.LORE, new ItemLore(List.of(Component.literal("I'm pickle riiick!!"))));
+					output.accept(stack);
 			})
 			.build();
 	// :::9


### PR DESCRIPTION
Instead of using `ItemGroupEvents.modifyEntriesEvent`, the `displayItems` method of the tab builder can be used when creating a custom tab.

The other method is still taught by the normal item guide, so no content is lost by this change. (Though maybe linking that guide might be useful?)