### PR TITLE
404: Yarn Not Found

### DIFF
--- a/.vitepress/theme/components/NotFoundComponent.vue
+++ b/.vitepress/theme/components/NotFoundComponent.vue
@@ -6,10 +6,8 @@ import { computed } from "vue";
 import { Fabric } from "../../types";
 
 const data = useData();
-
 const options = computed(() => data.theme.value.notFound as Fabric.NotFoundOptions);
 const removeForEnglishRegex = new RegExp(String.raw`^${data.localeIndex.value}/|\.md$`, "g");
-
 const urls = computed(() =>
   data.localeIndex.value === "root"
     ? {
@@ -30,22 +28,20 @@ const urls = computed(() =>
 <template>
   <div class="not-found">
     <code>{{ options.code }}</code>
-    <h1>{{ options.title.toUpperCase() }}</h1>
+    <h1>{{ options.title.toLocaleUpperCase(data.lang.value) }}</h1>
     <blockquote>{{ options.quote }}</blockquote>
 
-    <div>
-      <VPLink :href="urls.home" :aria-label="options.linkLabel">
-        {{ options.linkText }}
-      </VPLink>
-      <br />
-      <VPLink v-if="urls.english" :href="urls.english" :aria-label="options.englishLinkLabel">
-        {{ options.englishLinkText }}
-      </VPLink>
-      <br />
-      <VPLink v-if="urls.crowdin" :href="urls.crowdin" :aria-label="options.crowdinLinkLabel">
-        {{ options.crowdinLinkText }}
-      </VPLink>
-    </div>
+    <VPLink :href="urls.home" :aria-label="options.linkLabel">
+      {{ options.linkText }}
+    </VPLink>
+    <br />
+    <VPLink v-if="urls.english" :href="urls.english" :aria-label="options.englishLinkLabel">
+      {{ options.englishLinkText }}
+    </VPLink>
+    <br />
+    <VPLink v-if="urls.crowdin" :href="urls.crowdin" :aria-label="options.crowdinLinkLabel">
+      {{ options.crowdinLinkText }}
+    </VPLink>
   </div>
 </template>
 
@@ -53,6 +49,8 @@ const urls = computed(() =>
 .not-found {
   padding: 64px 24px 96px;
   text-align: center;
+  position: relative;
+  overflow: hidden;
 }
 
 @media (min-width: 768px) {

--- a/.vitepress/types.ts
+++ b/.vitepress/types.ts
@@ -107,7 +107,7 @@ export namespace Fabric {
     /**
      * Set custom not found description.
      *
-     * @default "This page tried to swim in lava"
+     * @default "This page got tangled in the yarn"
      */
     quote: string;
 

--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ layout: home
 
 hero:
   name: Fabric Documentation
-  tagline: The official curated documentation for Fabric,<br>a modding toolchain for Minecraft.
+  tagline: The official curated documentation for Fabric,<br />a modding toolchain for Minecraft.
 
 features:
   - title: Player Guides

--- a/website_translations.json
+++ b/website_translations.json
@@ -6,7 +6,7 @@
   "404.english_link.label": "Open the English version",
   "404.link": "Take Me Home",
   "404.link.label": "Go to the home page",
-  "404.quote": "This page tried to swim in lava",
+  "404.quote": "This page got tangled in the yarn",
   "404.title": "Page not found",
   "authors.heading": "Page Authors",
   "authors.no_github": "%s (not from GitHub)",


### PR DESCRIPTION
Add an animation of a ball of Yarn unrolling and weaving a thread behind it, almost like tumbleweed. The 404 text only appears after the ball crosses it.

I also changed the text from "This page tried to swim in lava" to "This page got tangled in the yarn".

The image comes from <https://github.com/FabricMC/community/blob/main/media/unascribed/png/yarn.png>.

## Rationale

- #444's redirects are actually 404 pages, so this avoids confusing the user with the 404 text because the yarn ball would not have finished rolling past the midpoint
- A tribute to Yarn, which went 404 last year
- It's fun and quirky, and it gives our docs some personality

| Name              | Link                                                                |
| :---------------: | :-----------------------------------------------------------------: |
| 😎 Deploy Preview | <https://deploy-preview-472--nimble-elf-d9d491.netlify.app/404> |