### PR TITLE
perf: no flags for locale switcher

### DIFF
--- a/.vitepress/i18n.ts
+++ b/.vitepress/i18n.ts
@@ -93,26 +93,15 @@ export const getLocales = () => {
       type: "language",
     });
 
-    // https://en.wikipedia.org/wiki/Regional_indicator_symbol
-    const flag = String.fromCodePoint(
-      ...locale
-        .slice(-2)
-        .toUpperCase()
-        .split("")
-        .map((char) => 127397 + char.charCodeAt(0))
-    );
-
-    const name = intl
-      .of(intlLocale)!
-      // Capitalize first character
-      .replace(/^\p{CWU}/u, (firstChar) => firstChar.toLocaleUpperCase(intlLocale));
-
     returned[locale === "en_us" ? "root" : locale] = {
-      description: resolver("description"),
-      label: `${flag} ${name}`,
-      lang: locale.replace("_", "-"),
+      lang: intlLocale,
       link: locale === "en_us" ? "/" : `/${locale}/`,
+      label: intl
+        .of(intlLocale)!
+        .replace(/^\p{CWU}/u, (firstChar) => firstChar.toLocaleUpperCase(intlLocale)),
+
       title: resolver("title"),
+      description: resolver("description"),
 
       themeConfig: {
         authors: {

--- a/.vitepress/theme/style.css
+++ b/.vitepress/theme/style.css
@@ -4,16 +4,6 @@
 */
 
 @font-face {
-  font-family: "Noto Color Emoji Flags";
-  font-style: normal;
-  font-display: swap;
-  font-weight: 400;
-  unicode-range: U+1F1E6-1F1FF;
-  src: url(@fontsource/noto-color-emoji/files/noto-color-emoji-emoji-400-normal.woff2)
-    format("woff2");
-}
-
-@font-face {
   font-family: "JetBrains Mono";
   font-style: normal;
   font-display: swap;
@@ -38,8 +28,8 @@
   --vp-home-hero-name-background: -webkit-linear-gradient(120deg, #3463fe 30%, #4787ff);
 
   --font-family-base:
-    "Inter", ui-sans-serif, system-ui, sans-serif, "Noto Color Emoji Flags", "Noto Color Emoji",
-    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    "Inter", ui-sans-serif, system-ui, sans-serif, "Noto Color Emoji", "Apple Color Emoji",
+    "Segoe UI Emoji", "Segoe UI Symbol";
   --vp-font-family-base: var(--font-family-base);
   --vp-font-family-mono:
     "JetBrains Mono", ui-monospace, "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
       "name": "fabric-docs",
       "dependencies": {
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
-        "@fontsource/noto-color-emoji": "^5.2.10",
         "@iconify/vue": "^5.0.0",
         "@vueuse/core": "^12.8.2",
         "markdown-it-vuepress-code-snippet-enhanced": "github:IMB11/md-it-enhanced-snippets#dfb9fa2",
@@ -595,15 +594,6 @@
       "version": "5.2.8",
       "resolved": "https://registry.npmjs.org/@fontsource-variable/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
       "integrity": "sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==",
-      "license": "OFL-1.1",
-      "funding": {
-        "url": "https://github.com/sponsors/ayuhito"
-      }
-    },
-    "node_modules/@fontsource/noto-color-emoji": {
-      "version": "5.2.10",
-      "resolved": "https://registry.npmjs.org/@fontsource/noto-color-emoji/-/noto-color-emoji-5.2.10.tgz",
-      "integrity": "sha512-sHu7Z2zkdmPbcNlNgqyQGJEis6fE3eBY8ZXzaUe5ixci2uCQ3g8cX5hJM+5P45JxTEhdbiU/4k3chQmDxe5puQ==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
-    "@fontsource/noto-color-emoji": "^5.2.10",
     "@iconify/vue": "^5.0.0",
     "@vueuse/core": "^12.8.2",
     "markdown-it-vuepress-code-snippet-enhanced": "github:IMB11/md-it-enhanced-snippets#dfb9fa2",


### PR DESCRIPTION
don't add flags to the locale switcher

## Rationale

- flags are not supported by default **on Windows**
- file size of `@fontsource/noto-color-emoji` is huge
  - it's tanking the performance and breaking #472
  - @CelDaemon managed to get it down to 700 kB, which is still big
- CountryFlagsPolyfill is out of date
- the version switcher doesn't have icons, why should the locales'

## Possibilities for the future

- Finding a way to compress Noto Color Emoji even further, possibly without doing it on every build
- Restoring the tracked CountryFlagsPolyfill file
- Using `iconify` to render the flag as an icon from Twemoji
- Rendering the flags as svgs (from where?)
- Making this solution permanent