### PR TITLE
Add `BlockColorRegistry` rename

### DIFF
--- a/develop/porting/26.1/fabric-api.md
+++ b/develop/porting/26.1/fabric-api.md
@@ -118,6 +118,8 @@ An IntelliJ IDEA migration map is also available to help automate renaming the c
 
 - `net/fabricmc/fabric/api/client/rendering/v1/BlockRenderLayerMap` → `ChunkSectionLayerMap`
 
+- `net/fabricmc/fabric/api/client/rendering/v1/ColorProviderRegistry.BLOCK` → `BlockColorRegistry`
+
 - `net/fabricmc/fabric/api/client/rendering/v1/DrawItemStackOverlayCallback` → `RenderItemDecorationsCallback`
   - `onDrawItemStackOverlay` → `onRenderItemDecorations`
 


### PR DESCRIPTION
https://github.com/FabricMC/fabric-api/pull/5140 renamed `ColorProviderRegistry.BLOCK` to `BlockColorRegistry`. This should be documented in the list of Fabric API renames.