### PR TITLE
docs: Fix incorrect axis description in blockstates.md 

### DIFF
--- a/develop/blocks/blockstates.md
+++ b/develop/blocks/blockstates.md
@@ -52,7 +52,7 @@ Next, we need to create a blockstate file, which is where the magic happens. Pil
 
 - `axis=x` - When the block is placed along the X axis, we will rotate the model to face the positive X direction.
 - `axis=y` - When the block is placed along the Y axis, we will use the normal vertical model.
-- `axis=z` - When the block is placed along the Z axis, we will rotate the model to face the positive X direction.
+- `axis=z` - When the block is placed along the Z axis, we will rotate the model to face the positive Z direction.
 
 @[code](@/reference/latest/src/main/generated/assets/example-mod/blockstates/condensed_oak_log.json)
 

--- a/versions/1.20.4/develop/blocks/blockstates.md
+++ b/versions/1.20.4/develop/blocks/blockstates.md
@@ -52,7 +52,7 @@ Next, we need to create a blockstate file. The blockstate file is where the magi
 
 - `axis=x` - When the block is placed along the X axis, we will rotate the model to face the positive X direction.
 - `axis=y` - When the block is placed along the Y axis, we will use the normal vertical model.
-- `axis=z` - When the block is placed along the Z axis, we will rotate the model to face the positive X direction.
+- `axis=z` - When the block is placed along the Z axis, we will rotate the model to face the positive Z direction.
 
 @[code](@/reference/1.20.4/src/main/resources/assets/example-mod/blockstates/condensed_oak_log.json)
 

--- a/versions/1.21.1/develop/blocks/blockstates.md
+++ b/versions/1.21.1/develop/blocks/blockstates.md
@@ -52,7 +52,7 @@ Next, we need to create a blockstate file. The blockstate file is where the magi
 
 - `axis=x` - When the block is placed along the X axis, we will rotate the model to face the positive X direction.
 - `axis=y` - When the block is placed along the Y axis, we will use the normal vertical model.
-- `axis=z` - When the block is placed along the Z axis, we will rotate the model to face the positive X direction.
+- `axis=z` - When the block is placed along the Z axis, we will rotate the model to face the positive Z direction.
 
 @[code](@/reference/1.21.1/src/main/resources/assets/example-mod/blockstates/condensed_oak_log.json)
 

--- a/versions/1.21.4/develop/blocks/blockstates.md
+++ b/versions/1.21.4/develop/blocks/blockstates.md
@@ -50,7 +50,7 @@ Next, we need to create a blockstate file, which is where the magic happens. Pil
 
 - `axis=x` - When the block is placed along the X axis, we will rotate the model to face the positive X direction.
 - `axis=y` - When the block is placed along the Y axis, we will use the normal vertical model.
-- `axis=z` - When the block is placed along the Z axis, we will rotate the model to face the positive X direction.
+- `axis=z` - When the block is placed along the Z axis, we will rotate the model to face the positive Z direction.
 
 @[code](@/reference/1.21.4/src/main/generated/assets/fabric-docs-reference/blockstates/condensed_oak_log.json)
 

--- a/versions/1.21.8/develop/blocks/blockstates.md
+++ b/versions/1.21.8/develop/blocks/blockstates.md
@@ -50,7 +50,7 @@ Next, we need to create a blockstate file, which is where the magic happens. Pil
 
 - `axis=x` - When the block is placed along the X axis, we will rotate the model to face the positive X direction.
 - `axis=y` - When the block is placed along the Y axis, we will use the normal vertical model.
-- `axis=z` - When the block is placed along the Z axis, we will rotate the model to face the positive X direction.
+- `axis=z` - When the block is placed along the Z axis, we will rotate the model to face the positive Z direction.
 
 @[code](@/reference/1.21.8/src/main/generated/assets/fabric-docs-reference/blockstates/condensed_oak_log.json)
 


### PR DESCRIPTION
## What this PR does
Fixes an incorrect description in the pillar block tutorial regarding the `axis=z` state.

## The Issue
The original documentation stated that when `axis=z`, the model should rotate to face the **positive X direction**. This is logically incorrect and contradicts the behavior of pillar blocks.

## The Fix
Changed the description to correctly state **positive Z direction**.

## Reasoning
A pillar block placed along the Z-axis must align with the Z-axis, not the X-axis. Keeping the original text would mislead modders into creating incorrect blockstates.

Blockstate orientation documentation update:

* Updated the explanation for the `axis=z` property in blockstate files to indicate that blocks placed along the Z axis should rotate the model to face the positive Z direction, correcting previous instructions that referenced the positive X direction. [[1]](diffhunk://#diff-1aaa943256dd1af68d62a66b2c5b5343954f9c164253a8ddd1ffd8303f8e7ec4L55-R55) [[2]](diffhunk://#diff-045bd240c352c4f1f21d48e427d83f9bf366b7c8e48bc839598a1c907570ccb9L55-R55) [[3]](diffhunk://#diff-20afc6a5ac8caaef2d8b919ffa410d55f96f15d9895d09c18f0bdd4bdc567f57L55-R55) [[4]](diffhunk://#diff-bd1f32117d20630b263a65e71b7e8c867e3202647123869f6eadc0522688d05bL53-R53) [[5]](diffhunk://#diff-21847157397327d815b877480da66dfda8c88c7cb19fafeeef8b91bb833e63c4L53-R53)