### PR TITLE
Fix crash when opening inventory

### DIFF
--- a/reference/latest/src/client/java/com/example/docs/ExampleModClient.java
+++ b/reference/latest/src/client/java/com/example/docs/ExampleModClient.java
@@ -24,11 +24,9 @@ public class ExampleModClient implements ClientModInitializer {
 		ItemTooltipCallback.EVENT.register((stack, context, type, tooltip) -> {
 			Integer count = stack.get(ModComponents.CLICK_COUNT_COMPONENT);
 
-			if (count == null) {
-				return;
+			if (count != null) {
+				tooltip.add(Component.translatable("item.example-mod.counter.info", count).withStyle(ChatFormatting.GOLD));
 			}
-
-			tooltip.add(Component.translatable("item.example-mod.counter.info", count).withStyle(ChatFormatting.GOLD));
 		});
 		// #tooltip_provider_client
 	}

--- a/reference/latest/src/client/java/com/example/docs/ExampleModClient.java
+++ b/reference/latest/src/client/java/com/example/docs/ExampleModClient.java
@@ -22,7 +22,12 @@ public class ExampleModClient implements ClientModInitializer {
 
 		// #tooltip_provider_client
 		ItemTooltipCallback.EVENT.register((stack, context, type, tooltip) -> {
-			int count = stack.get(ModComponents.CLICK_COUNT_COMPONENT);
+			Integer count = stack.get(ModComponents.CLICK_COUNT_COMPONENT);
+
+			if (count == null) {
+				return;
+			}
+
 			tooltip.add(Component.translatable("item.example-mod.counter.info", count).withStyle(ChatFormatting.GOLD));
 		});
 		// #tooltip_provider_client


### PR DESCRIPTION
Fixes the exception thrown by the example tooltip callback. This exception occurs when handling the tooltip of any item that does not have the counter component. Due to a `get` returning a null value, unboxing to an `int` primitive fails instead of being handled gracefully.