### PR TITLE
Fix container tooltip and saving

### DIFF
--- a/develop/blocks/container-menus.md
+++ b/develop/blocks/container-menus.md
@@ -2,6 +2,7 @@
 title: Container Menus
 description: A guide explaining how to create a simple menu for a container block.
 authors:
+  - CelDaemon
   - Tenneb22
 ---
 
@@ -33,6 +34,10 @@ First, we want to create a block and block entity; read more in the [Block Conta
 As we want a 3x3 container, we need to set the size of items to 9.
 
 :::
+
+We will also need to save our items, we can do this by overriding the `saveAdditional` and `loadAdditional` methods.
+
+@[code transcludeWith=:::save](@/reference/latest/src/main/java/com/example/docs/block/entity/custom/DirtChestBlockEntity.java)
 
 ### Opening the Menu {#opening-the-screen}
 

--- a/develop/blocks/container-menus.md
+++ b/develop/blocks/container-menus.md
@@ -35,10 +35,6 @@ As we want a 3x3 container, we need to set the size of items to 9.
 
 :::
 
-We will also need to save our items, we can do this by overriding the `saveAdditional` and `loadAdditional` methods.
-
-@[code transcludeWith=:::save](@/reference/latest/src/main/java/com/example/docs/block/entity/custom/DirtChestBlockEntity.java)
-
 ### Opening the Menu {#opening-the-screen}
 
 We want to be able to open the menu somehow, so we will handle that within the `useWithoutItem` method:

--- a/develop/blocks/container-menus.md
+++ b/develop/blocks/container-menus.md
@@ -29,12 +29,6 @@ First, we want to create a block and block entity; read more in the [Block Conta
 
 @[code transcludeWith=:::be](@/reference/latest/src/main/java/com/example/docs/block/entity/custom/DirtChestBlockEntity.java)
 
-::: info
-
-As we want a 3x3 container, we need to set the size of items to 9.
-
-:::
-
 ### Opening the Menu {#opening-the-screen}
 
 We want to be able to open the menu somehow, so we will handle that within the `useWithoutItem` method:

--- a/reference/latest/src/client/java/com/example/docs/rendering/screens/inventory/DirtChestScreen.java
+++ b/reference/latest/src/client/java/com/example/docs/rendering/screens/inventory/DirtChestScreen.java
@@ -31,5 +31,13 @@ public class DirtChestScreen extends AbstractContainerScreen<DirtChestMenu> {
 		int yo = (this.height - this.imageHeight) / 2;
 		graphics.blit(RenderPipelines.GUI_TEXTURED, CONTAINER_TEXTURE, xo, yo, 0.0F, 0.0F, this.imageWidth, this.imageHeight, BACKGROUND_TEXTURE_WIDTH, BACKGROUND_TEXTURE_HEIGHT);
 	}
+
+	@Override
+	public void render(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+		super.render(graphics, mouseX, mouseY, delta);
+
+		// Render item tooltips
+		this.renderTooltip(graphics, mouseX, mouseY);
+	}
 }
 // :::screen

--- a/reference/latest/src/main/java/com/example/docs/block/entity/custom/DirtChestBlockEntity.java
+++ b/reference/latest/src/main/java/com/example/docs/block/entity/custom/DirtChestBlockEntity.java
@@ -51,15 +51,6 @@ public class DirtChestBlockEntity extends BlockEntity implements ImplementedCont
 		return items;
 	}
 
-	// :::menu
-	@Override
-	@NonNull
-	public Component getDisplayName() {
-		return Component.translatable("block.example-mod.dirt_chest");
-	}
-
-	// :::menu
-	// :::save
 	@Override
 	protected void saveAdditional(ValueOutput valueOutput) {
 		super.saveAdditional(valueOutput);
@@ -71,7 +62,15 @@ public class DirtChestBlockEntity extends BlockEntity implements ImplementedCont
 		super.loadAdditional(valueInput);
 		ContainerHelper.loadAllItems(valueInput, items);
 	}
-	// :::save
+
+	// :::menu
+	@Override
+	@NonNull
+	public Component getDisplayName() {
+		return Component.translatable("block.example-mod.dirt_chest");
+	}
+
+	// :::menu
 
 	/*
 	// :::menu

--- a/reference/latest/src/main/java/com/example/docs/block/entity/custom/DirtChestBlockEntity.java
+++ b/reference/latest/src/main/java/com/example/docs/block/entity/custom/DirtChestBlockEntity.java
@@ -32,7 +32,7 @@ public class DirtChestBlockEntity extends BlockEntity implements ImplementedCont
 	// :::menu
 
 	// :::be
-	private static final int CONTAINER_SIZE = 9;
+	public static final int CONTAINER_SIZE = 3 * 3;
 	private final NonNullList<ItemStack> items = NonNullList.withSize(CONTAINER_SIZE, ItemStack.EMPTY);
 
 	// ...

--- a/reference/latest/src/main/java/com/example/docs/block/entity/custom/DirtChestBlockEntity.java
+++ b/reference/latest/src/main/java/com/example/docs/block/entity/custom/DirtChestBlockEntity.java
@@ -6,6 +6,7 @@ import org.jspecify.annotations.Nullable;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.NonNullList;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.ContainerHelper;
 import net.minecraft.world.MenuProvider;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
@@ -13,6 +14,8 @@ import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.storage.ValueInput;
+import net.minecraft.world.level.storage.ValueOutput;
 
 import com.example.docs.block.entity.ModBlockEntities;
 import com.example.docs.container.ImplementedContainer;
@@ -56,6 +59,19 @@ public class DirtChestBlockEntity extends BlockEntity implements ImplementedCont
 	}
 
 	// :::menu
+	// :::save
+	@Override
+	protected void saveAdditional(ValueOutput valueOutput) {
+		super.saveAdditional(valueOutput);
+		ContainerHelper.saveAllItems(valueOutput, items);
+	}
+
+	@Override
+	protected void loadAdditional(ValueInput valueInput) {
+		super.loadAdditional(valueInput);
+		ContainerHelper.loadAllItems(valueInput, items);
+	}
+	// :::save
 
 	/*
 	// :::menu

--- a/reference/latest/src/main/java/com/example/docs/menu/custom/DirtChestMenu.java
+++ b/reference/latest/src/main/java/com/example/docs/menu/custom/DirtChestMenu.java
@@ -8,22 +8,22 @@ import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 
+import com.example.docs.block.entity.custom.DirtChestBlockEntity;
 import com.example.docs.menu.ModMenuType;
 
 // :::menu
 public class DirtChestMenu extends AbstractContainerMenu {
-	private static final int CONTAINER_SIZE = 9;
 	private final Container container;
 
 	// Client-side constructor
 	public DirtChestMenu(final int containerId, final Inventory inventory) {
-		this(containerId, inventory, new SimpleContainer(CONTAINER_SIZE));
+		this(containerId, inventory, new SimpleContainer(DirtChestBlockEntity.CONTAINER_SIZE));
 	}
 
 	// Server-side constructor
 	public DirtChestMenu(final int containerId, final Inventory inventory, final Container container) {
 		super(ModMenuType.DIRT_CHEST, containerId);
-		checkContainerSize(container, CONTAINER_SIZE);
+		checkContainerSize(container, DirtChestBlockEntity.CONTAINER_SIZE);
 		this.container = container;
 
 		// Some containers do custom logic when opened by a player.


### PR DESCRIPTION
The recently added container menu documentation has a custom screen, which currently does not show tooltips.
It also doesn't seem to save items, which is a pretty important part of a container BE.
