### PR TITLE
Register entity renderer

### DIFF
--- a/develop/entities/first-entity.md
+++ b/develop/entities/first-entity.md
@@ -118,6 +118,10 @@ A entity's renderer enables you to view your entity in-game. We'll create a new 
 
 This is also where the shadow radius is set, for this entity that will be `0.375f`.
 
+This renderer must then be registered in the mod's client initializer.
+
+@[code transcludeWith=::register_renderer](@/reference/latest/src/client/java/com/example/docs/entity/ExampleModCustomEntityClient.java)
+
 ### Adding Walking Animations {#walking-animations}
 
 The following code can be added to the `MiniGolemEntityModel` class to give the entity a walking animation.

--- a/reference/latest/src/client/java/com/example/docs/entity/ExampleModCustomEntityClient.java
+++ b/reference/latest/src/client/java/com/example/docs/entity/ExampleModCustomEntityClient.java
@@ -7,7 +7,6 @@ import net.fabricmc.api.ClientModInitializer;
 import com.example.docs.entity.model.ModEntityModelLayers;
 import com.example.docs.entity.renderer.MiniGolemEntityRenderer;
 
-//:::register_renderer
 //:::register_client
 public class ExampleModCustomEntityClient implements ClientModInitializer {
 	@Override
@@ -21,4 +20,3 @@ public class ExampleModCustomEntityClient implements ClientModInitializer {
 	}
 }
 //:::register_client
-//:::register_renderer

--- a/reference/latest/src/client/java/com/example/docs/entity/ExampleModCustomEntityClient.java
+++ b/reference/latest/src/client/java/com/example/docs/entity/ExampleModCustomEntityClient.java
@@ -7,14 +7,18 @@ import net.fabricmc.api.ClientModInitializer;
 import com.example.docs.entity.model.ModEntityModelLayers;
 import com.example.docs.entity.renderer.MiniGolemEntityRenderer;
 
+//:::register_renderer
 //:::register_client
 public class ExampleModCustomEntityClient implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
 		ModEntityModelLayers.registerModelLayers();
 		//:::register_client
+		//:::register_renderer
 		EntityRenderers.register(ModEntityTypes.MINI_GOLEM, MiniGolemEntityRenderer::new);
+		//:::register_renderer
 		//:::register_client
 	}
 }
 //:::register_client
+//:::register_renderer


### PR DESCRIPTION
Entity renderers are currently not registered, causing a crash without a proper explanation when people try and spawn their entity. The transclusions here are less than ideal, but we'll be merging #529 soon anyway so it's fine for now.