### PR TITLE
Fix keymapping categories being registered incorrectly

### DIFF
--- a/reference/latest/src/client/java/com/example/docs/keymapping/ExampleModKeyMappingsClient.java
+++ b/reference/latest/src/client/java/com/example/docs/keymapping/ExampleModKeyMappingsClient.java
@@ -15,7 +15,7 @@ import com.example.docs.ExampleMod;
 
 public class ExampleModKeyMappingsClient implements ClientModInitializer {
 	// :::category
-	KeyMapping.Category CATEGORY = new KeyMapping.Category(
+	KeyMapping.Category CATEGORY = KeyMapping.Category.register(
 			Identifier.fromNamespaceAndPath(ExampleMod.MOD_ID, "custom_category")
 	);
 	// :::category


### PR DESCRIPTION
Registering `KeyMapping.Category` with the constructor causes it to be sorted incorrectly.