### PR TITLE
Indicate Loom version in CT introduction

### DIFF
--- a/develop/class-tweakers/index.md
+++ b/develop/class-tweakers/index.md
@@ -12,7 +12,7 @@ Class tweakers, formerly known as access wideners before gaining further functio
 
 ::: warning
 
-Class tweakers are not specific to a given Minecraft version, but are only available starting from Fabric Loader 0.18.0, and may only target Vanilla Minecraft classes.
+Class tweakers are not specific to a given Minecraft version, but are only available starting from Fabric Loader 0.18.0 and Loom 1.12, and may only target Vanilla Minecraft classes.
 
 :::
 

--- a/versions/1.21.11/develop/class-tweakers/index.md
+++ b/versions/1.21.11/develop/class-tweakers/index.md
@@ -12,7 +12,7 @@ Class tweakers, formerly known as access wideners before gaining further functio
 
 ::: warning
 
-Class tweakers are not specific to a given Minecraft version, but are only available starting from Fabric Loader 0.18.0, and may only target Vanilla Minecraft classes.
+Class tweakers are not specific to a given Minecraft version, but are only available starting from Fabric Loader 0.18.0 and Loom 1.12, and may only target Vanilla Minecraft classes.
 
 :::
 


### PR DESCRIPTION
Tiny single-commit PR that indicates Loom 1.12 is required to use CT files. I'm basing this off of the fact that `validateAccessWidener` fails on CT files on 1.11-SNAPSHOT but not on 1.12-SNAPSHOT.

This PR applies to both the 26.1 page and the 1.21.11 page.

Reviews are welcome but I don't think there's too much double checking needed given only a couple words are added.