### PR TITLE
Improve networking tutorial

### DIFF
--- a/develop/networking.md
+++ b/develop/networking.md
@@ -86,7 +86,7 @@ Before we send a packet with our custom payload, we need to register it on both 
 This can be done in our **common initializer** by using `PayloadTypeRegistry.clientboundPlay().register` which takes in a
 `CustomPayload.Type` and a `StreamCodec`.
 
-@[code lang=java transclude={25-25}](@/reference/latest/src/main/java/com/example/docs/networking/basic/ExampleModNetworkingBasic.java)
+@[code lang=java transclude={14-14}](@/reference/latest/src/main/java/com/example/docs/networking/basic/ExampleModNetworkingBasic.java)
 
 A similar method exists to register client-to-server payloads: `PayloadTypeRegistry.serverboundPlay().register`.
 
@@ -168,7 +168,7 @@ We pass in the appropriate codec along with a method reference to get the value 
 Then we register our payload in our **common initializer**. However, this time as _Client-to-Server_ payload by using
 `PayloadTypeRegistry.serverboundPlay().register`.
 
-@[code lang=java transclude={26-26}](@/reference/latest/src/main/java/com/example/docs/networking/basic/ExampleModNetworkingBasic.java)
+@[code lang=java transclude={15-15}](@/reference/latest/src/main/java/com/example/docs/networking/basic/ExampleModNetworkingBasic.java)
 
 To send a packet, let's add an action when the player uses a Poisonous Potato. We'll be using the `UseEntityCallback`
 event to

--- a/develop/networking.md
+++ b/develop/networking.md
@@ -2,6 +2,7 @@
 title: Networking
 description: A general guide on networking using Fabric API.
 authors:
+  - bluebear94
   - Daomephsta
   - dicedpixels
   - Earthcomputer
@@ -55,28 +56,28 @@ A payload is the data that is sent within a packet.
 
 This can be done by creating a Java `Record` with a `BlockPos` parameter that implements `CustomPacketPayload`.
 
-@[code lang=java transcludeWith=:::summon_Lightning_payload](@/reference/latest/src/main/java/com/example/docs/networking/basic/SummonLightningClientboundPayload.java)
+@[code lang=java transcludeWith=:::summon_Lightning_payload](@/reference/latest/src/main/java/com/example/docs/networking/basic/ClientboundSummonLightningPayload.java)
 
 At the same time, we've defined:
 
 - An `Identifier` used to identify our packet's payload. For this example our identifier will be
   `example-mod:summon_lightning`.
 
-@[code lang=java transclude={13-13}](@/reference/latest/src/main/java/com/example/docs/networking/basic/SummonLightningClientboundPayload.java)
+@[code lang=java transclude={13-13}](@/reference/latest/src/main/java/com/example/docs/networking/basic/ClientboundSummonLightningPayload.java)
 
 - A public static instance of `CustomPayload.Type` to uniquely identify this custom payload. We will be referencing this
   ID in both our common and client code.
 
-@[code lang=java transclude={14-14}](@/reference/latest/src/main/java/com/example/docs/networking/basic/SummonLightningClientboundPayload.java)
+@[code lang=java transclude={14-14}](@/reference/latest/src/main/java/com/example/docs/networking/basic/ClientboundSummonLightningPayload.java)
 
 - A public static instance of a `StreamCodec` so that the game knows how to serialize/deserialize the contents of the
   packet.
 
-@[code lang=java transclude={15-15}](@/reference/latest/src/main/java/com/example/docs/networking/basic/SummonLightningClientboundPayload.java)
+@[code lang=java transclude={15-15}](@/reference/latest/src/main/java/com/example/docs/networking/basic/ClientboundSummonLightningPayload.java)
 
 We have also overridden `type` to return our payload ID.
 
-@[code lang=java transclude={17-20}](@/reference/latest/src/main/java/com/example/docs/networking/basic/SummonLightningClientboundPayload.java)
+@[code lang=java transclude={17-20}](@/reference/latest/src/main/java/com/example/docs/networking/basic/ClientboundSummonLightningPayload.java)
 
 ### Registering a Payload {#registering-a-payload}
 

--- a/reference/latest/src/client/java/com/example/docs/network/basic/ExampleModNetworkingBasicClient.java
+++ b/reference/latest/src/client/java/com/example/docs/network/basic/ExampleModNetworkingBasicClient.java
@@ -15,8 +15,8 @@ import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.event.player.UseEntityCallback;
 
-import com.example.docs.networking.basic.GiveGlowingEffectServerboundPayload;
 import com.example.docs.networking.basic.ClientboundSummonLightningPayload;
+import com.example.docs.networking.basic.GiveGlowingEffectServerboundPayload;
 
 public class ExampleModNetworkingBasicClient implements ClientModInitializer {
 	@Override

--- a/reference/latest/src/client/java/com/example/docs/network/basic/ExampleModNetworkingBasicClient.java
+++ b/reference/latest/src/client/java/com/example/docs/network/basic/ExampleModNetworkingBasicClient.java
@@ -16,13 +16,13 @@ import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.event.player.UseEntityCallback;
 
 import com.example.docs.networking.basic.GiveGlowingEffectServerboundPayload;
-import com.example.docs.networking.basic.SummonLightningClientboundPayload;
+import com.example.docs.networking.basic.ClientboundSummonLightningPayload;
 
 public class ExampleModNetworkingBasicClient implements ClientModInitializer {
 	@Override
 	public void onInitializeClient() {
 		// :::client_global_receiver
-		ClientPlayNetworking.registerGlobalReceiver(SummonLightningClientboundPayload.TYPE, (payload, context) -> {
+		ClientPlayNetworking.registerGlobalReceiver(ClientboundSummonLightningPayload.TYPE, (payload, context) -> {
 			ClientLevel level = context.client().level;
 
 			if (level == null) {

--- a/reference/latest/src/main/java/com/example/docs/networking/basic/ClientboundSummonLightningPayload.java
+++ b/reference/latest/src/main/java/com/example/docs/networking/basic/ClientboundSummonLightningPayload.java
@@ -11,7 +11,7 @@ import com.example.docs.ExampleMod;
 // :::summon_Lightning_payload
 public record ClientboundSummonLightningPayload(BlockPos pos) implements CustomPacketPayload {
 	public static final Identifier SUMMON_LIGHTNING_PAYLOAD_ID = Identifier.fromNamespaceAndPath(ExampleMod.MOD_ID, "summon_lightning");
-	public static final CustomPacketPayload.Type<ClientboundSummonLightningPayload> TYPE = new CustomPacketPayload.Type<>( SUMMON_LIGHTNING_PAYLOAD_ID);
+	public static final CustomPacketPayload.Type<ClientboundSummonLightningPayload> TYPE = new CustomPacketPayload.Type<>(SUMMON_LIGHTNING_PAYLOAD_ID);
 	public static final StreamCodec<RegistryFriendlyByteBuf, ClientboundSummonLightningPayload> CODEC = StreamCodec.composite(BlockPos.STREAM_CODEC, ClientboundSummonLightningPayload::pos, ClientboundSummonLightningPayload::new);
 
 	@Override

--- a/reference/latest/src/main/java/com/example/docs/networking/basic/ClientboundSummonLightningPayload.java
+++ b/reference/latest/src/main/java/com/example/docs/networking/basic/ClientboundSummonLightningPayload.java
@@ -9,10 +9,10 @@ import net.minecraft.resources.Identifier;
 import com.example.docs.ExampleMod;
 
 // :::summon_Lightning_payload
-public record SummonLightningClientboundPayload(BlockPos pos) implements CustomPacketPayload {
+public record ClientboundSummonLightningPayload(BlockPos pos) implements CustomPacketPayload {
 	public static final Identifier SUMMON_LIGHTNING_PAYLOAD_ID = Identifier.fromNamespaceAndPath(ExampleMod.MOD_ID, "summon_lightning");
-	public static final CustomPacketPayload.Type<SummonLightningClientboundPayload> TYPE = new CustomPacketPayload.Type<>(SUMMON_LIGHTNING_PAYLOAD_ID);
-	public static final StreamCodec<RegistryFriendlyByteBuf, SummonLightningClientboundPayload> CODEC = StreamCodec.composite(BlockPos.STREAM_CODEC, SummonLightningClientboundPayload::pos, SummonLightningClientboundPayload::new);
+	public static final CustomPacketPayload.Type<ClientboundSummonLightningPayload> TYPE = new CustomPacketPayload.Type<>( SUMMON_LIGHTNING_PAYLOAD_ID);
+	public static final StreamCodec<RegistryFriendlyByteBuf, ClientboundSummonLightningPayload> CODEC = StreamCodec.composite(BlockPos.STREAM_CODEC, ClientboundSummonLightningPayload::pos, ClientboundSummonLightningPayload::new);
 
 	@Override
 	public Type<? extends CustomPacketPayload> type() {

--- a/reference/latest/src/main/java/com/example/docs/networking/basic/ExampleModNetworkingBasic.java
+++ b/reference/latest/src/main/java/com/example/docs/networking/basic/ExampleModNetworkingBasic.java
@@ -11,7 +11,7 @@ import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 
 public class ExampleModNetworkingBasic implements ModInitializer {
 	public void onInitialize() {
-		PayloadTypeRegistry.clientboundPlay().register(SummonLightningClientboundPayload.TYPE, SummonLightningClientboundPayload.CODEC);
+		PayloadTypeRegistry.clientboundPlay().register(ClientboundSummonLightningPayload.TYPE, ClientboundSummonLightningPayload.CODEC);
 		PayloadTypeRegistry.serverboundPlay().register(GiveGlowingEffectServerboundPayload.TYPE, GiveGlowingEffectServerboundPayload.CODEC);
 
 		// :::server_global_receiver

--- a/reference/latest/src/main/java/com/example/docs/networking/basic/LightningTaterItem.java
+++ b/reference/latest/src/main/java/com/example/docs/networking/basic/LightningTaterItem.java
@@ -23,7 +23,7 @@ public class LightningTaterItem extends Item {
 			return InteractionResult.PASS;
 		}
 
-		SummonLightningClientboundPayload payload = new SummonLightningClientboundPayload(user.blockPosition());
+		ClientboundSummonLightningPayload payload = new ClientboundSummonLightningPayload(user.blockPosition());
 
 		for (ServerPlayer player : PlayerLookup.level((ServerLevel) level)) {
 			ServerPlayNetworking.send(player, payload);


### PR DESCRIPTION
Rename `SummonLightningClientboundPayload` to `ClientboundSummonLightningPayload` to be more consistent with the official naming conventions for packet classes, and also fixes some line references.