### PR TITLE
Mapping articles fixes

### DIFF
--- a/develop/porting/mappings/index.md
+++ b/develop/porting/mappings/index.md
@@ -62,7 +62,7 @@ Neither option is perfect, and you still have to review the results and make man
 
 Historically, Minecraft: Java Edition has made use of obfuscation, which led to the development of obfuscation maps that Fabric Loom uses for modding. There were two choices: either Fabric's own Yarn mappings, or the official Mojang mappings.
 
-Mojang recently released [the first release of Minecraft: Java Edition with unobfuscated code](https://www.minecraft.net/en-us/article/removing-obfuscation-in-java-edition), and the Fabric Project made the decision to [not keep maintaning third-party mappings](https://fabricmc.net/2025/10/31/obfuscation.html) from this version onward. If you plan to update your mod to this version, you will need to switch to Mojang's mappings first before updating.
+Mojang recently released [the first release of Minecraft: Java Edition with unobfuscated code](https://www.minecraft.net/en-us/article/removing-obfuscation-in-java-edition), and the Fabric Project made the decision to [not keep maintaining third-party mappings](https://fabricmc.net/2025/10/31/obfuscation.html) from this version onward. If you plan to update your mod to this version, you will need to switch to Mojang's mappings first before updating.
 
 ## What Are Mappings? {#mappings}
 

--- a/versions/1.21.11/develop/porting/mappings/loom.md
+++ b/versions/1.21.11/develop/porting/mappings/loom.md
@@ -62,17 +62,11 @@ dependencies {
 
 You can now refresh the Gradle project in your IDE to apply your changes.
 
-### Final Changes {#final-changes-mojmap}
+### Final Changes {#final-changes}
 
 That's the bulk of the work done! You'll now want to go through your source code to check for any potentially outdated Mixin targets or code that was not remapped.
 
 Tools like [mappings.dev](https://mappings.dev/) or [Linkie](https://linkie.shedaniel.dev/mappings?namespace=yarn&translateMode=ns&translateAs=mojang_raw&search=) will be helpful to familiarize yourself with your new mappings.
-
-### Final Changes {#final-changes-yarn}
-
-That's the bulk of the work done! You'll now want to go through your source code to check for any potentially outdated Mixin targets or code that was not remapped.
-
-Tools like [mappings.dev](https://mappings.dev/) or [Linkie](https://linkie.shedaniel.dev/mappings?namespace=mojang_raw&translateMode=ns&translateAs=yarn&search=) will be helpful to familiarize yourself with your new mappings.
 
 ## Additional Configurations {#additional-configurations}
 


### PR DESCRIPTION
- Fix duplicated "final changes" section on migrateMappings page.
- Fix typo on index page.