### PR TITLE
Fix missing quoting in split sources modid

### DIFF
--- a/develop/loom/index.md
+++ b/develop/loom/index.md
@@ -61,18 +61,7 @@ The following snippet from a `build.gradle` file shows how you can enable this f
 
 Minecraft 1.18 (1.19 recommended), Loader 0.14 and Loom 1.0 or later are required to split the client and common code.
 
-```groovy
-loom {
- splitEnvironmentSourceSets()
-
- mods {
-   example-mod {
-     sourceSet sourceSets.main
-     sourceSet sourceSets.client
-   }
- }
- }
-```
+<<< @/reference/build.gradle#split-sources
 
 ## Resolving Issues {#issues}
 

--- a/reference/build.gradle
+++ b/reference/build.gradle
@@ -13,6 +13,7 @@ subprojects {
 		archivesName = "example-mod-${project.name}"
 	}
 
+	// #region split-sources
 	loom {
 		splitEnvironmentSourceSets()
 
@@ -22,7 +23,10 @@ subprojects {
 				sourceSet sourceSets.client
 			}
 		}
+	}
+	// #endregion split-sources
 
+	loom {
 		runs.configureEach {
 			ideConfigGenerated = true
 		}


### PR DESCRIPTION
The current example has invalid syntax that is not actually accepted by Gradle.