### PR TITLE
chore: bump to 26.1.2

### DIFF
--- a/reference/latest/build.gradle
+++ b/reference/latest/build.gradle
@@ -1,5 +1,5 @@
-def minecraftVersion = "26.1.1"
-def fabricApiVersion = "0.145.4+26.1.1"
+def minecraftVersion = "26.1.2"
+def fabricApiVersion = "0.146.1+26.1.2"
 
 // :::automatic-testing:game-test:2
 dependencies {


### PR DESCRIPTION
Bumps the docs version to the latest (and hopefully last) hotfix for 26.1, 26.1.2.