### PR TITLE
Fix syncing in counter block

### DIFF
--- a/develop/blocks/block-entities.md
+++ b/develop/blocks/block-entities.md
@@ -106,11 +106,9 @@ Now, when a player logs in or moves into a chunk where the block exists, they wi
 
 ## Syncing Data {#syncing-data}
 
-While new players loading in the block will see the correct count, other players watching the interaction will not see the count update; causing a desync.
+While new players loading in the block will see the correct count, the count will not update for other players watching the interaction. This phenomenon is called a desync, and it occurs when the server has updated its state, but the clients haven't.
 
-To solve this, we can use block entity update packets.
-
-Override the `getUpdatePacket` method, and return a packet containing the block's data from our `getUpdateTag`.
+To solve this, we can use block entity update packets. Override the `getUpdatePacket` method, and return a packet containing the block's data from our `getUpdateTag`.
 
 <<< @/reference/latest/src/main/java/com/example/docs/block/entity/custom/CounterBlockEntity.java#update-packet
 

--- a/develop/blocks/block-entities.md
+++ b/develop/blocks/block-entities.md
@@ -2,6 +2,7 @@
 title: Block Entities
 description: Learn how to create block entities for your custom blocks.
 authors:
+  - CelDaemon
   - natri0
 resources:
   https://docs.neoforged.net/docs/blockentities/: Block Entities - NeoForge Docs
@@ -102,6 +103,22 @@ To fix this, we override `getUpdateTag`:
 @[code transcludeWith=:::7](@/reference/latest/src/main/java/com/example/docs/block/entity/custom/CounterBlockEntity.java)
 
 Now, when a player logs in or moves into a chunk where the block exists, they will see the correct counter value right away.
+
+## Syncing Data {#syncing-data}
+
+While new players loading in the block will see the correct count, other players watching the interaction will not see the count update; causing a desync.
+
+To solve this, we can use block entity update packets.
+
+Override the `getUpdatePacket` method, and return a packet containing the block's data from our `getUpdateTag`.
+
+<<< @/reference/latest/src/main/java/com/example/docs/block/entity/custom/CounterBlockEntity.java#update-packet
+
+Then, override `setChanged` to broadcast the data whenever the block entity changes.
+
+<<< @/reference/latest/src/main/java/com/example/docs/block/entity/custom/CounterBlockEntity.java#broadcast-update
+
+Other players should now be able to see the count changing.
 
 ## Tickers {#tickers}
 

--- a/reference/latest/src/main/java/com/example/docs/block/custom/CounterBlock.java
+++ b/reference/latest/src/main/java/com/example/docs/block/custom/CounterBlock.java
@@ -49,7 +49,7 @@ public class CounterBlock extends BaseEntityBlock {
 			player.sendOverlayMessage(Component.literal("You've clicked the block for the " + counterBlockEntity.getClicks() + "th time."));
 		}
 
-		return InteractionResult.SUCCESS.withoutItem();
+		return InteractionResult.SUCCESS;
 	}
 	// :::2
 

--- a/reference/latest/src/main/java/com/example/docs/block/custom/CounterBlock.java
+++ b/reference/latest/src/main/java/com/example/docs/block/custom/CounterBlock.java
@@ -44,9 +44,12 @@ public class CounterBlock extends BaseEntityBlock {
 		}
 
 		counterBlockEntity.incrementClicks();
-		player.sendOverlayMessage(Component.literal("You've clicked the block for the " + counterBlockEntity.getClicks() + "th time."));
 
-		return InteractionResult.SUCCESS;
+		if (level.isClientSide()) {
+			player.sendOverlayMessage(Component.literal("You've clicked the block for the " + counterBlockEntity.getClicks() + "th time."));
+		}
+
+		return InteractionResult.SUCCESS.withoutItem();
 	}
 	// :::2
 

--- a/reference/latest/src/main/java/com/example/docs/block/entity/custom/CounterBlockEntity.java
+++ b/reference/latest/src/main/java/com/example/docs/block/entity/custom/CounterBlockEntity.java
@@ -3,7 +3,11 @@ package com.example.docs.block.entity.custom;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ClientGamePacketListener;
+import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.storage.ValueInput;
@@ -46,6 +50,18 @@ public class CounterBlockEntity extends BlockEntity {
 	}
 	// :::2
 
+	// #region broadcast-update
+	@Override
+	public void setChanged() {
+		super.setChanged();
+
+		if (level != null) {
+			BlockState state = getBlockState();
+			level.sendBlockUpdated(worldPosition, state, state, Block.UPDATE_ALL);
+		}
+	}
+	// #endregion broadcast-update
+
 	// :::3
 	@Override
 	protected void saveAdditional(ValueOutput output) {
@@ -76,6 +92,13 @@ public class CounterBlockEntity extends BlockEntity {
 		return saveWithoutMetadata(registryLookup);
 	}
 	// :::7
+
+	// #region update-packet
+	@Override
+	public Packet<ClientGamePacketListener> getUpdatePacket() {
+		return ClientboundBlockEntityDataPacket.create(this);
+	}
+	// #endregion update-packet
 
 	// :::1
 }

--- a/reference/latest/src/main/java/com/example/docs/block/entity/custom/CounterBlockEntity.java
+++ b/reference/latest/src/main/java/com/example/docs/block/entity/custom/CounterBlockEntity.java
@@ -55,10 +55,10 @@ public class CounterBlockEntity extends BlockEntity {
 	public void setChanged() {
 		super.setChanged();
 
-		if (level != null) {
-			BlockState state = getBlockState();
-			level.sendBlockUpdated(worldPosition, state, state, Block.UPDATE_ALL);
-		}
+		if (level == null) return;
+
+		BlockState state = getBlockState();
+		level.sendBlockUpdated(worldPosition, state, state, Block.UPDATE_ALL);
 	}
 	// #endregion broadcast-update
 


### PR DESCRIPTION
Adds a small section about using update packets, allowing other players to see the changes to the counter block without relogging.

Also fixes the overlay message to only send locally on the client.