### PR TITLE
fix some usages of `Identifier`

### DIFF
--- a/reference/latest/src/client/java/com/example/docs/datagen/ExampleModDamageTypesProvider.java
+++ b/reference/latest/src/client/java/com/example/docs/datagen/ExampleModDamageTypesProvider.java
@@ -30,7 +30,7 @@ public class ExampleModDamageTypesProvider {
 
 		@Override
 		protected void addTags(HolderLookup.Provider arg) {
-			builder(TagKey.create(Registries.DAMAGE_TYPE, Identifier.parse("minecraft:bypasses_armor"))).add(ExampleModDamageTypes.TATER_DAMAGE);
+			builder(TagKey.create(Registries.DAMAGE_TYPE, Identifier.withDefaultNamespace("bypasses_armor"))).add(ExampleModDamageTypes.TATER_DAMAGE);
 		}
 	}
 

--- a/reference/latest/src/client/java/com/example/docs/rendering/DrawContextExampleScreen.java
+++ b/reference/latest/src/client/java/com/example/docs/rendering/DrawContextExampleScreen.java
@@ -58,7 +58,7 @@ public class DrawContextExampleScreen extends Screen {
 		// :::4
 
 		// :::5
-		Identifier texture = Identifier.fromNamespaceAndPath("minecraft", "textures/block/deepslate.png");
+		Identifier texture = Identifier.withDefaultNamespace("textures/block/deepslate.png");
 		// renderLayer, texture, x, y, u, v, width, height, textureWidth, textureHeight
 		graphics.blit(RenderPipelines.GUI_TEXTURED, texture, 90, 90, 0, 0, 16, 16, 16, 16);
 		// :::5

--- a/reference/latest/src/main/java/com/example/docs/ExampleMod.java
+++ b/reference/latest/src/main/java/com/example/docs/ExampleMod.java
@@ -46,7 +46,7 @@ public class ExampleMod implements ModInitializer {
 
 		//#particle_register_main
 		// Register our custom particle type in the mod initializer.
-		Registry.register(BuiltInRegistries.PARTICLE_TYPE, Identifier.fromNamespaceAndPath(MOD_ID, "sparkle_particle"), SPARKLE_PARTICLE);
+		Registry.register(BuiltInRegistries.PARTICLE_TYPE, Identifier.fromNamespaceAndPath(ExampleMod.MOD_ID, "sparkle_particle"), SPARKLE_PARTICLE);
 		//#particle_register_main
 		// :::datagen-world:biome-modifications
 		// Spawns everywhere in the overworld

--- a/reference/latest/src/main/java/com/example/docs/advancement/ModCriteria.java
+++ b/reference/latest/src/main/java/com/example/docs/advancement/ModCriteria.java
@@ -1,6 +1,7 @@
 package com.example.docs.advancement;
 
 import net.minecraft.advancements.CriteriaTriggers;
+import net.minecraft.resources.Identifier;
 
 import com.example.docs.ExampleMod;
 
@@ -8,10 +9,10 @@ import com.example.docs.ExampleMod;
 public class ModCriteria {
 	// :::datagen-advancements:mod-criteria-init
 	// :::datagen-advancements:mod-criteria
-	public static final UseToolCriterion USE_TOOL = CriteriaTriggers.register(ExampleMod.MOD_ID + ":use_tool", new UseToolCriterion());
+	public static final UseToolCriterion USE_TOOL = CriteriaTriggers.register(Identifier.fromNamespaceAndPath(ExampleMod.MOD_ID, "use_tool").toString(), new UseToolCriterion());
 	// :::datagen-advancements:mod-criteria
 	// :::datagen-advancements:new-mod-criteria
-	public static final ParameterizedUseToolCriterion PARAMETERIZED_USE_TOOL = CriteriaTriggers.register(ExampleMod.MOD_ID + ":parameterized_use_tool", new ParameterizedUseToolCriterion());
+	public static final ParameterizedUseToolCriterion PARAMETERIZED_USE_TOOL = CriteriaTriggers.register(Identifier.fromNamespaceAndPath(ExampleMod.MOD_ID, "parameterized_use_tool").toString(), new ParameterizedUseToolCriterion());
 
 	// :::datagen-advancements:mod-criteria
 	// :::datagen-advancements:mod-criteria-init

--- a/reference/latest/src/main/java/com/example/docs/attachment/ExampleModAttachments.java
+++ b/reference/latest/src/main/java/com/example/docs/attachment/ExampleModAttachments.java
@@ -7,16 +7,18 @@ import net.fabricmc.fabric.api.attachment.v1.AttachmentRegistry;
 import net.fabricmc.fabric.api.attachment.v1.AttachmentSyncPredicate;
 import net.fabricmc.fabric.api.attachment.v1.AttachmentType;
 
+import com.example.docs.ExampleMod;
+
 public class ExampleModAttachments {
 	// :::string
 	public static final AttachmentType<String> EXAMPLE_STRING_ATTACHMENT = AttachmentRegistry.create(
-			Identifier.fromNamespaceAndPath("example-mod", "example_string_attachment") // The ID of your Attachment
+			Identifier.fromNamespaceAndPath(ExampleMod.MOD_ID, "example_string_attachment") // The ID of your Attachment
 	);
 	// :::string
 
 	// :::pos
 	public static final AttachmentType<BlockPos> EXAMPLE_BLOCK_POS_ATTACHMENT = AttachmentRegistry.create(
-			Identifier.fromNamespaceAndPath("example-mod", "example_block_pos_attachment"),
+			Identifier.fromNamespaceAndPath(ExampleMod.MOD_ID, "example_block_pos_attachment"),
 			builder -> builder
 				.initializer(() -> new BlockPos(0, 0, 0)) // The default value of the Attachment, if one has not been set.
 				.syncWith(
@@ -28,7 +30,7 @@ public class ExampleModAttachments {
 
 	// :::persistent
 	public static final AttachmentType<BlockPos> EXAMPLE_PERSISTENT_ATTACHMENT = AttachmentRegistry.create(
-			Identifier.fromNamespaceAndPath("example-mod", "example_block_pos_attachment"),
+			Identifier.fromNamespaceAndPath(ExampleMod.MOD_ID, "example_block_pos_attachment"),
 			builder -> builder
 				.initializer(() -> new BlockPos(0, 0, 0)) // The default value of the Attachment, if one has not been set.
 				.persistent(BlockPos.CODEC) // Dictates how this Attachment's data should be saved and loaded.

--- a/reference/latest/src/main/java/com/example/docs/attachment/Stamina.java
+++ b/reference/latest/src/main/java/com/example/docs/attachment/Stamina.java
@@ -8,14 +8,16 @@ import net.fabricmc.fabric.api.attachment.v1.AttachmentSyncPredicate;
 import net.fabricmc.fabric.api.attachment.v1.AttachmentTarget;
 import net.fabricmc.fabric.api.attachment.v1.AttachmentType;
 
+import com.example.docs.ExampleMod;
+
 // :::stamina
 public class Stamina {
 	private static final AttachmentType<Integer> CURRENT_STAMINA = AttachmentRegistry.create(
-					Identifier.fromNamespaceAndPath("example-mod", "current_stamina"),
+					Identifier.fromNamespaceAndPath(ExampleMod.MOD_ID, "current_stamina"),
 					builder -> builder.syncWith(ByteBufCodecs.INT, AttachmentSyncPredicate.all())
 	);
 	private static final AttachmentType<Integer> MAX_STAMINA = AttachmentRegistry.create(
-					Identifier.fromNamespaceAndPath("example-mod", "max_stamina"),
+					Identifier.fromNamespaceAndPath(ExampleMod.MOD_ID, "max_stamina"),
 					builder -> builder.syncWith(ByteBufCodecs.INT, AttachmentSyncPredicate.all())
 	);
 

--- a/reference/latest/src/main/java/com/example/docs/codec/BeanType.java
+++ b/reference/latest/src/main/java/com/example/docs/codec/BeanType.java
@@ -8,12 +8,14 @@ import net.minecraft.core.Registry;
 import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
 
+import com.example.docs.ExampleMod;
+
 // :::
 // A record to keep information relating to a specific
 // subclass of Bean, in this case only holding a Codec.
 public record BeanType<T extends Bean>(MapCodec<T> codec) {
 	// Create a registry to map identifiers to bean types
 	public static final Registry<BeanType<?>> REGISTRY = new MappedRegistry<>(
-			ResourceKey.createRegistryKey(Identifier.fromNamespaceAndPath("example", "bean_types")), Lifecycle.stable());
+			ResourceKey.createRegistryKey(Identifier.fromNamespaceAndPath(ExampleMod.MOD_ID, "bean_types")), Lifecycle.stable());
 }
 // :::

--- a/reference/latest/src/main/java/com/example/docs/codec/BeanTypes.java
+++ b/reference/latest/src/main/java/com/example/docs/codec/BeanTypes.java
@@ -3,6 +3,8 @@ package com.example.docs.codec;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.Identifier;
 
+import com.example.docs.ExampleMod;
+
 // :::
 // An empty class to hold static references to all BeanTypes
 public class BeanTypes {
@@ -16,7 +18,7 @@ public class BeanTypes {
 
 	//:::
 	public static <T extends Bean> BeanType<T> register(String id, BeanType<T> beanType) {
-		return Registry.register(BeanType.REGISTRY, Identifier.fromNamespaceAndPath("example", id), beanType);
+		return Registry.register(BeanType.REGISTRY, Identifier.fromNamespaceAndPath(ExampleMod.MOD_ID, id), beanType);
 	}
 }
 // :::

--- a/reference/latest/src/main/java/com/example/docs/command/ExampleModCommands.java
+++ b/reference/latest/src/main/java/com/example/docs/command/ExampleModCommands.java
@@ -20,6 +20,8 @@ import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.ArgumentTypeRegistry;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 
+import com.example.docs.ExampleMod;
+
 // Class to contain all mod command registrations.
 public class ExampleModCommands implements ModInitializer {
 	// :::execute_dedicated_command
@@ -121,7 +123,7 @@ public class ExampleModCommands implements ModInitializer {
 	public void onInitialize() {
 		// :::register_custom_arg
 		ArgumentTypeRegistry.registerArgumentType(
-				Identifier.fromNamespaceAndPath("fabric-docs", "block_pos"),
+				Identifier.fromNamespaceAndPath(ExampleMod.MOD_ID, "block_pos"),
 				BlockPosArgumentType.class,
 				SingletonArgumentInfo.contextFree(BlockPosArgumentType::new)
 		);

--- a/reference/latest/src/main/java/com/example/docs/debug/ExampleModDebug.java
+++ b/reference/latest/src/main/java/com/example/docs/debug/ExampleModDebug.java
@@ -1,29 +1,24 @@
 package com.example.docs.debug;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import net.fabricmc.api.ModInitializer;
+
+import com.example.docs.ExampleMod;
 
 // :::problems:basic-logger-definition
 public class ExampleModDebug implements ModInitializer {
-	public static final String MOD_ID = "example-mod";
-	public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
-
-	// ...
 	// :::problems:basic-logger-definition
 
 	@Override
 	public void onInitialize() {
 		// :::problems:debug-logging
-		LOGGER.debug("Debug logging is enabled");
+		ExampleMod.LOGGER.debug("Debug logging is enabled");
 		// :::problems:debug-logging
 
 		// :::problems:log-levels
-		ExampleModDebug.LOGGER.debug("Debug message for development...");
-		ExampleModDebug.LOGGER.info("Neutral, informative text...");
-		ExampleModDebug.LOGGER.warn("Non-critical issues..."); // [!code warning]
-		ExampleModDebug.LOGGER.error("Critical exceptions, bugs..."); // [!code error]
+		ExampleMod.LOGGER.debug("Debug message for development...");
+		ExampleMod.LOGGER.info("Neutral, informative text...");
+		ExampleMod.LOGGER.warn("Non-critical issues..."); // [!code warning]
+		ExampleMod.LOGGER.error("Critical exceptions, bugs..."); // [!code error]
 		// :::problems:log-levels
 	}
 

--- a/reference/latest/src/main/java/com/example/docs/debug/TestItem.java
+++ b/reference/latest/src/main/java/com/example/docs/debug/TestItem.java
@@ -15,6 +15,8 @@ import net.minecraft.world.level.block.state.BlockState;
 
 import net.fabricmc.fabric.api.tag.convention.v2.ConventionalBlockTags;
 
+import com.example.docs.ExampleMod;
+
 public class TestItem extends Item {
 	public TestItem(Properties settings) {
 		super(settings);
@@ -28,7 +30,7 @@ public class TestItem extends Item {
 		// ::::::problems:logger-usage-example
 		if (level.isClientSide()) {
 			// :::problems:using-logger
-			ExampleModDebug.LOGGER.info("You interacted with an entity!");
+			ExampleMod.LOGGER.info("You interacted with an entity!");
 			// :::problems:using-logger
 		}
 
@@ -38,16 +40,16 @@ public class TestItem extends Item {
 		String output = "Is Client World: %s | Health: %s / %s | The item was used with the %s"
 				.formatted(user.level().isClientSide(), entity.getHealth(), entity.getMaxHealth(), hand.name());
 
-		ExampleModDebug.LOGGER.info(output);
+		ExampleMod.LOGGER.info(output);
 
 		if (!user.level().isClientSide()) {
 			// you can log non-critical issues differently as a warning
-			ExampleModDebug.LOGGER.warn("Don't touch that!");
+			ExampleMod.LOGGER.warn("Don't touch that!");
 
 			// The LOGGER can print the Stacktrace too in addition to the logging message
 			if (stack.getCount() > 1) {
 				IllegalArgumentException exception = new IllegalArgumentException("Only one item is allowed");
-				ExampleModDebug.LOGGER.error("Error while interacting with an entity", exception);
+				ExampleMod.LOGGER.error("Error while interacting with an entity", exception);
 				throw exception;
 			}
 		}

--- a/reference/latest/src/main/java/com/example/docs/networking/ExampleModNetworking.java
+++ b/reference/latest/src/main/java/com/example/docs/networking/ExampleModNetworking.java
@@ -15,6 +15,6 @@ public class ExampleModNetworking implements ModInitializer {
 	}
 
 	public static Identifier getId(String input) {
-		return Identifier.fromNamespaceAndPath(MOD_ID, input);
+		return Identifier.fromNamespaceAndPath(ExampleMod.MOD_ID, input);
 	}
 }

--- a/reference/latest/src/main/java/com/example/docs/networking/ExampleModNetworking.java
+++ b/reference/latest/src/main/java/com/example/docs/networking/ExampleModNetworking.java
@@ -7,8 +7,6 @@ import net.fabricmc.api.ModInitializer;
 import com.example.docs.ExampleMod;
 
 public class ExampleModNetworking implements ModInitializer {
-	public static final String MOD_ID = ExampleMod.MOD_ID;
-
 	@Override
 	public void onInitialize() {
 		NetworkPayloads.initialize();

--- a/reference/latest/src/main/java/com/example/docs/sound/CustomSounds.java
+++ b/reference/latest/src/main/java/com/example/docs/sound/CustomSounds.java
@@ -5,6 +5,8 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.Identifier;
 import net.minecraft.sounds.SoundEvent;
 
+import com.example.docs.ExampleMod;
+
 // :::1
 public class CustomSounds {
 	private CustomSounds() {
@@ -18,14 +20,14 @@ public class CustomSounds {
 
 	// actual registration of all the custom SoundEvents
 	private static SoundEvent registerSound(String id) {
-		Identifier identifier = Identifier.fromNamespaceAndPath(ExampleModSounds.MOD_ID, id);
+		Identifier identifier = Identifier.fromNamespaceAndPath(ExampleMod.MOD_ID, id);
 		return Registry.register(BuiltInRegistries.SOUND_EVENT, identifier, SoundEvent.createVariableRangeEvent(identifier));
 	}
 
 	// This static method starts class initialization, which then initializes
 	// the static class variables (e.g. ITEM_METAL_WHISTLE).
 	public static void initialize() {
-		ExampleModSounds.LOGGER.info("Registering " + ExampleModSounds.MOD_ID + " Sounds");
+		ExampleModSounds.LOGGER.info("Registering " + ExampleMod.MOD_ID + " Sounds");
 		// Technically this method can stay empty, but some developers like to notify
 		// the console, that certain parts of the mod have been successfully initialized
 	}

--- a/reference/latest/src/main/java/com/example/docs/sound/CustomSounds.java
+++ b/reference/latest/src/main/java/com/example/docs/sound/CustomSounds.java
@@ -27,7 +27,7 @@ public class CustomSounds {
 	// This static method starts class initialization, which then initializes
 	// the static class variables (e.g. ITEM_METAL_WHISTLE).
 	public static void initialize() {
-		ExampleModSounds.LOGGER.info("Registering " + ExampleMod.MOD_ID + " Sounds");
+		ExampleMod.LOGGER.info("Registering " + ExampleMod.MOD_ID + " Sounds");
 		// Technically this method can stay empty, but some developers like to notify
 		// the console, that certain parts of the mod have been successfully initialized
 	}

--- a/reference/latest/src/main/java/com/example/docs/sound/ExampleModSounds.java
+++ b/reference/latest/src/main/java/com/example/docs/sound/ExampleModSounds.java
@@ -20,8 +20,8 @@ public class ExampleModSounds implements ModInitializer {
 	public void onInitialize() {
 		// This is the basic registering. Use a new class for registering sounds
 		// instead, to keep the ModInitializer implementing class clean!
-		Registry.register(BuiltInRegistries.SOUND_EVENT, Identifier.fromNamespaceAndPath(MOD_ID, "metal_whistle_simple"),
-				SoundEvent.createVariableRangeEvent(Identifier.fromNamespaceAndPath(MOD_ID, "metal_whistle_simple")));
+		Registry.register(BuiltInRegistries.SOUND_EVENT, Identifier.fromNamespaceAndPath(ExampleMod.MOD_ID, "metal_whistle_simple"),
+				SoundEvent.createVariableRangeEvent(Identifier.fromNamespaceAndPath(ExampleMod.MOD_ID, "metal_whistle_simple")));
 
 		// ... the cleaner approach. // [!code focus]
 		CustomSounds.initialize(); // [!code focus]

--- a/reference/latest/src/main/java/com/example/docs/sound/ExampleModSounds.java
+++ b/reference/latest/src/main/java/com/example/docs/sound/ExampleModSounds.java
@@ -1,7 +1,5 @@
 package com.example.docs.sound;
 
-import org.slf4j.Logger;
-
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.Identifier;
@@ -13,9 +11,6 @@ import com.example.docs.ExampleMod;
 
 // :::2
 public class ExampleModSounds implements ModInitializer {
-	public static final String MOD_ID = ExampleMod.MOD_ID;
-	public static final Logger LOGGER = ExampleMod.LOGGER;
-
 	@Override
 	public void onInitialize() {
 		// This is the basic registering. Use a new class for registering sounds

--- a/reference/latest/src/test/java/com/example/docs/codec/BeanTypeTest.java
+++ b/reference/latest/src/test/java/com/example/docs/codec/BeanTypeTest.java
@@ -31,7 +31,7 @@ public class BeanTypeTest {
 	@Test
 	void testBeanCodec() {
 		StringyBean expectedBean = new StringyBean("This bean is stringy!");
-		Bean actualBean = Bean.BEAN_CODEC.parse(JsonOps.INSTANCE, GSON.fromJson("{\"type\":\"example:stringy_bean\",\"stringy_string\":\"This bean is stringy!\"}", JsonObject.class)).getOrThrow();
+		Bean actualBean = Bean.BEAN_CODEC.parse(JsonOps.INSTANCE, GSON.fromJson("{\"type\":\"example-mod:stringy_bean\",\"stringy_string\":\"This bean is stringy!\"}", JsonObject.class)).getOrThrow();
 
 		Assertions.assertInstanceOf(StringyBean.class, actualBean);
 		Assertions.assertEquals(expectedBean.getType(), actualBean.getType());


### PR DESCRIPTION
- ~~Applies FabricMC/fabric-api#5366~~ #594 already takes care of that
- Why do some initializers have `MOD_ID = ExampleMod.MOD_ID` instead of just using `ExampleMod.MOD_ID`?
- The third commit had some weird identifiers; I used "example-mod" for those
- The fourth commit changes `+` to `Identifier#toString`, not sure if it's good practice