### PR TITLE
Remove 26.1 info from 1.21.11 archive

### DIFF
--- a/.vitepress/sidebars/versioned/1.21.11-bg_bg.json
+++ b/.vitepress/sidebars/versioned/1.21.11-bg_bg.json
@@ -369,16 +369,7 @@
           "text": "Porting to 1.21.11",
           "link": "/bg_bg/develop/porting/"
         },
-        {
-          "text": "Porting to 26.1 Snapshots",
-          "link": "/bg_bg/develop/porting/26.1",
-          "items": [
-            {
-              "text": "Fabric API",
-              "link": "/bg_bg/develop/porting/26.1/fabric-api"
-            }
-          ]
-        },
+        
         {
           "text": "Migrating Mappings",
           "link": "/bg_bg/develop/porting/mappings/",

--- a/.vitepress/sidebars/versioned/1.21.11-cs_cz.json
+++ b/.vitepress/sidebars/versioned/1.21.11-cs_cz.json
@@ -369,16 +369,7 @@
           "text": "Porting to 1.21.11",
           "link": "/cs_cz/develop/porting/"
         },
-        {
-          "text": "Porting to 26.1 Snapshots",
-          "link": "/cs_cz/develop/porting/26.1",
-          "items": [
-            {
-              "text": "Fabric API",
-              "link": "/cs_cz/develop/porting/26.1/fabric-api"
-            }
-          ]
-        },
+        
         {
           "text": "Migrating Mappings",
           "link": "/cs_cz/develop/porting/mappings/",

--- a/.vitepress/sidebars/versioned/1.21.11-de_de.json
+++ b/.vitepress/sidebars/versioned/1.21.11-de_de.json
@@ -369,16 +369,7 @@
           "text": "Porting to 1.21.11",
           "link": "/de_de/develop/porting/"
         },
-        {
-          "text": "Porting to 26.1 Snapshots",
-          "link": "/de_de/develop/porting/26.1",
-          "items": [
-            {
-              "text": "Fabric API",
-              "link": "/de_de/develop/porting/26.1/fabric-api"
-            }
-          ]
-        },
+        
         {
           "text": "Migrating Mappings",
           "link": "/de_de/develop/porting/mappings/",

--- a/.vitepress/sidebars/versioned/1.21.11-el_gr.json
+++ b/.vitepress/sidebars/versioned/1.21.11-el_gr.json
@@ -369,16 +369,7 @@
           "text": "Porting to 1.21.11",
           "link": "/el_gr/develop/porting/"
         },
-        {
-          "text": "Porting to 26.1 Snapshots",
-          "link": "/el_gr/develop/porting/26.1",
-          "items": [
-            {
-              "text": "Fabric API",
-              "link": "/el_gr/develop/porting/26.1/fabric-api"
-            }
-          ]
-        },
+        
         {
           "text": "Migrating Mappings",
           "link": "/el_gr/develop/porting/mappings/",

--- a/.vitepress/sidebars/versioned/1.21.11-es_es.json
+++ b/.vitepress/sidebars/versioned/1.21.11-es_es.json
@@ -369,16 +369,7 @@
           "text": "Porting to 1.21.11",
           "link": "/es_es/develop/porting/"
         },
-        {
-          "text": "Porting to 26.1 Snapshots",
-          "link": "/es_es/develop/porting/26.1",
-          "items": [
-            {
-              "text": "Fabric API",
-              "link": "/es_es/develop/porting/26.1/fabric-api"
-            }
-          ]
-        },
+        
         {
           "text": "Migrating Mappings",
           "link": "/es_es/develop/porting/mappings/",

--- a/.vitepress/sidebars/versioned/1.21.11-fi_fi.json
+++ b/.vitepress/sidebars/versioned/1.21.11-fi_fi.json
@@ -369,16 +369,7 @@
           "text": "Porting to 1.21.11",
           "link": "/fi_fi/develop/porting/"
         },
-        {
-          "text": "Porting to 26.1 Snapshots",
-          "link": "/fi_fi/develop/porting/26.1",
-          "items": [
-            {
-              "text": "Fabric API",
-              "link": "/fi_fi/develop/porting/26.1/fabric-api"
-            }
-          ]
-        },
+        
         {
           "text": "Migrating Mappings",
           "link": "/fi_fi/develop/porting/mappings/",

--- a/.vitepress/sidebars/versioned/1.21.11-fr_fr.json
+++ b/.vitepress/sidebars/versioned/1.21.11-fr_fr.json
@@ -369,16 +369,7 @@
           "text": "Porting to 1.21.11",
           "link": "/fr_fr/develop/porting/"
         },
-        {
-          "text": "Porting to 26.1 Snapshots",
-          "link": "/fr_fr/develop/porting/26.1",
-          "items": [
-            {
-              "text": "Fabric API",
-              "link": "/fr_fr/develop/porting/26.1/fabric-api"
-            }
-          ]
-        },
+        
         {
           "text": "Migrating Mappings",
           "link": "/fr_fr/develop/porting/mappings/",

--- a/.vitepress/sidebars/versioned/1.21.11-it_it.json
+++ b/.vitepress/sidebars/versioned/1.21.11-it_it.json
@@ -369,16 +369,7 @@
           "text": "Aggiornamento a 1.21.11",
           "link": "/it_it/develop/porting/"
         },
-        {
-          "text": "Aggiornamento agli snapshot 26.1",
-          "link": "/it_it/develop/porting/26.1",
-          "items": [
-            {
-              "text": "API di Fabric",
-              "link": "/it_it/develop/porting/26.1/fabric-api"
-            }
-          ]
-        },
+        
         {
           "text": "Migrare ad altri mapping",
           "link": "/it_it/develop/porting/mappings/",

--- a/.vitepress/sidebars/versioned/1.21.11-ja_jp.json
+++ b/.vitepress/sidebars/versioned/1.21.11-ja_jp.json
@@ -369,16 +369,7 @@
           "text": "Porting to 1.21.11",
           "link": "/ja_jp/develop/porting/"
         },
-        {
-          "text": "Porting to 26.1 Snapshots",
-          "link": "/ja_jp/develop/porting/26.1",
-          "items": [
-            {
-              "text": "Fabric API",
-              "link": "/ja_jp/develop/porting/26.1/fabric-api"
-            }
-          ]
-        },
+        
         {
           "text": "Migrating Mappings",
           "link": "/ja_jp/develop/porting/mappings/",

--- a/.vitepress/sidebars/versioned/1.21.11-ko_kr.json
+++ b/.vitepress/sidebars/versioned/1.21.11-ko_kr.json
@@ -369,16 +369,7 @@
           "text": "Porting to 1.21.11",
           "link": "/ko_kr/develop/porting/"
         },
-        {
-          "text": "Porting to 26.1 Snapshots",
-          "link": "/ko_kr/develop/porting/26.1",
-          "items": [
-            {
-              "text": "Fabric API",
-              "link": "/ko_kr/develop/porting/26.1/fabric-api"
-            }
-          ]
-        },
+        
         {
           "text": "Migrating Mappings",
           "link": "/ko_kr/develop/porting/mappings/",

--- a/.vitepress/sidebars/versioned/1.21.11-ms_my.json
+++ b/.vitepress/sidebars/versioned/1.21.11-ms_my.json
@@ -369,16 +369,7 @@
           "text": "Porting to 1.21.11",
           "link": "/ms_my/develop/porting/"
         },
-        {
-          "text": "Porting to 26.1 Snapshots",
-          "link": "/ms_my/develop/porting/26.1",
-          "items": [
-            {
-              "text": "Fabric API",
-              "link": "/ms_my/develop/porting/26.1/fabric-api"
-            }
-          ]
-        },
+        
         {
           "text": "Migrating Mappings",
           "link": "/ms_my/develop/porting/mappings/",

--- a/.vitepress/sidebars/versioned/1.21.11-pl_pl.json
+++ b/.vitepress/sidebars/versioned/1.21.11-pl_pl.json
@@ -369,16 +369,7 @@
           "text": "Porting to 1.21.11",
           "link": "/pl_pl/develop/porting/"
         },
-        {
-          "text": "Porting to 26.1 Snapshots",
-          "link": "/pl_pl/develop/porting/26.1",
-          "items": [
-            {
-              "text": "Fabric API",
-              "link": "/pl_pl/develop/porting/26.1/fabric-api"
-            }
-          ]
-        },
+        
         {
           "text": "Migrating Mappings",
           "link": "/pl_pl/develop/porting/mappings/",

--- a/.vitepress/sidebars/versioned/1.21.11-pt_br.json
+++ b/.vitepress/sidebars/versioned/1.21.11-pt_br.json
@@ -369,16 +369,7 @@
           "text": "Porting to 1.21.11",
           "link": "/pt_br/develop/porting/"
         },
-        {
-          "text": "Porting to 26.1 Snapshots",
-          "link": "/pt_br/develop/porting/26.1",
-          "items": [
-            {
-              "text": "Fabric API",
-              "link": "/pt_br/develop/porting/26.1/fabric-api"
-            }
-          ]
-        },
+        
         {
           "text": "Migrating Mappings",
           "link": "/pt_br/develop/porting/mappings/",

--- a/.vitepress/sidebars/versioned/1.21.11-ru_ru.json
+++ b/.vitepress/sidebars/versioned/1.21.11-ru_ru.json
@@ -369,16 +369,7 @@
           "text": "Porting to 1.21.11",
           "link": "/ru_ru/develop/porting/"
         },
-        {
-          "text": "Porting to 26.1 Snapshots",
-          "link": "/ru_ru/develop/porting/26.1",
-          "items": [
-            {
-              "text": "Fabric API",
-              "link": "/ru_ru/develop/porting/26.1/fabric-api"
-            }
-          ]
-        },
+        
         {
           "text": "Migrating Mappings",
           "link": "/ru_ru/develop/porting/mappings/",

--- a/.vitepress/sidebars/versioned/1.21.11-zh_cn.json
+++ b/.vitepress/sidebars/versioned/1.21.11-zh_cn.json
@@ -369,16 +369,7 @@
           "text": "Porting to 1.21.11",
           "link": "/zh_cn/develop/porting/"
         },
-        {
-          "text": "Porting to 26.1 Snapshots",
-          "link": "/zh_cn/develop/porting/26.1",
-          "items": [
-            {
-              "text": "Fabric API",
-              "link": "/zh_cn/develop/porting/26.1/fabric-api"
-            }
-          ]
-        },
+        
         {
           "text": "Migrating Mappings",
           "link": "/zh_cn/develop/porting/mappings/",

--- a/.vitepress/sidebars/versioned/1.21.11-zh_tw.json
+++ b/.vitepress/sidebars/versioned/1.21.11-zh_tw.json
@@ -369,16 +369,7 @@
           "text": "Porting to 1.21.11",
           "link": "/zh_tw/develop/porting/"
         },
-        {
-          "text": "Porting to 26.1 Snapshots",
-          "link": "/zh_tw/develop/porting/26.1",
-          "items": [
-            {
-              "text": "Fabric API",
-              "link": "/zh_tw/develop/porting/26.1/fabric-api"
-            }
-          ]
-        },
+        
         {
           "text": "Migrating Mappings",
           "link": "/zh_tw/develop/porting/mappings/",

--- a/.vitepress/sidebars/versioned/1.21.11.json
+++ b/.vitepress/sidebars/versioned/1.21.11.json
@@ -369,16 +369,7 @@
           "text": "Porting to 1.21.11",
           "link": "/develop/porting/"
         },
-        {
-          "text": "Porting to 26.1 Snapshots",
-          "link": "/develop/porting/26.1",
-          "items": [
-            {
-              "text": "Fabric API",
-              "link": "/develop/porting/26.1/fabric-api"
-            }
-          ]
-        },
+        
         {
           "text": "Migrating Mappings",
           "link": "/develop/porting/mappings/",


### PR DESCRIPTION
The 26.1 snapshot pages only existed in the 1.21.11 sidebar as there was no 26.1 documentation to put it in. Now that 26.1 is released and documented, there is no need to keep these pages in the 1.21.11 sidebar.