### PR TITLE
Fix dyeable information

### DIFF
--- a/develop/data-generation/item-models.md
+++ b/develop/data-generation/item-models.md
@@ -120,7 +120,7 @@ The method for dyeable items generates a simple item model and a client item whi
 
 ::: warning IMPORTANT
 
-You have to add your item to the `ItemTags.DYEABLE` tag to be able to dye it in your inventory!
+You have to make a `DyeRecipe` for your item to be able to dye it in your inventory!
 
 :::
 

--- a/develop/data-generation/item-models.md
+++ b/develop/data-generation/item-models.md
@@ -120,7 +120,7 @@ The method for dyeable items generates a simple item model and a client item whi
 
 ::: warning IMPORTANT
 
-You have to make a `DyeRecipe` for your item to be able to dye it in your inventory!
+You have to make a [`DyeRecipe`](./recipes#dye-recipes) for your item to be able to dye it in your inventory!
 
 :::
 

--- a/develop/data-generation/recipes.md
+++ b/develop/data-generation/recipes.md
@@ -34,6 +34,12 @@ Shapeless recipes are fairly straightforward. Just add them to the `buildRecipes
 
 @[code lang=java transcludeWith=:::datagen-recipes:shapeless](@/reference/latest/src/client/java/com/example/docs/datagen/ExampleModRecipeProvider.java)
 
+### Dye Recipes {#dye-recipes}
+
+Dye recipes are used to dye items in your inventory.
+
+<<< @/reference/latest/src/client/java/com/example/docs/datagen/ExampleModRecipeProvider.java#datagen-recipes--dye
+
 ## Shaped Recipes {#shaped-recipes}
 
 For a shaped recipe, you define the shape using a `String`, then define what each `char` in the `String` represents.

--- a/reference/latest/src/client/java/com/example/docs/datagen/ExampleModRecipeProvider.java
+++ b/reference/latest/src/client/java/com/example/docs/datagen/ExampleModRecipeProvider.java
@@ -18,6 +18,8 @@ import net.minecraft.world.item.crafting.Ingredient;
 import net.fabricmc.fabric.api.datagen.v1.FabricPackOutput;
 import net.fabricmc.fabric.api.datagen.v1.provider.FabricRecipeProvider;
 
+import com.example.docs.item.ModItems;
+
 public class ExampleModRecipeProvider extends FabricRecipeProvider {
 	public ExampleModRecipeProvider(FabricPackOutput output, CompletableFuture<HolderLookup.Provider> registriesFuture) {
 		super(output, registriesFuture);
@@ -69,6 +71,9 @@ public class ExampleModRecipeProvider extends FabricRecipeProvider {
 						"food_to_wheat" // group
 				);
 				// :::datagen-recipes:other
+				// #region datagen-recipes--dye
+				dyedItem(ModItems.LEATHER_GLOVES, "leather_gloves");
+				// #endregion datagen-recipes--dye
 				// :::datagen-recipes:provider
 			}
 		};

--- a/reference/latest/src/main/generated/data/minecraft/advancement/recipes/misc/leather_gloves_dyed.json
+++ b/reference/latest/src/main/generated/data/minecraft/advancement/recipes/misc/leather_gloves_dyed.json
@@ -1,0 +1,32 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_leather_gloves": {
+      "conditions": {
+        "items": [
+          {
+            "items": "example-mod:leather_gloves"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "minecraft:leather_gloves_dyed"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_the_recipe",
+      "has_leather_gloves"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "minecraft:leather_gloves_dyed"
+    ]
+  }
+}

--- a/reference/latest/src/main/generated/data/minecraft/recipe/leather_gloves_dyed.json
+++ b/reference/latest/src/main/generated/data/minecraft/recipe/leather_gloves_dyed.json
@@ -1,0 +1,10 @@
+{
+  "type": "minecraft:crafting_dye",
+  "category": "misc",
+  "dye": "#minecraft:dyes",
+  "group": "leather_gloves",
+  "result": {
+    "id": "example-mod:leather_gloves"
+  },
+  "target": "example-mod:leather_gloves"
+}


### PR DESCRIPTION
Model generation page still references `ItemTags.DYEABLE`, which was removed in 26.1. 