### PR TITLE
Add ExampleMod id helper

### DIFF
--- a/develop/getting-started/project-structure.md
+++ b/develop/getting-started/project-structure.md
@@ -35,6 +35,12 @@ Here's an example of a simple `main` entrypoint that logs a message to the conso
 
 <<< @/reference/latest/src/main/java/com/example/docs/ExampleMod.java#entrypoint
 
+The example also provides a small `id` helper that creates identifiers in the mod's namespace. This keeps later registry calls concise and avoids repeating the mod ID each time you need an identifier:
+
+```java
+ExampleMod.id("example_path")
+```
+
 ## `src/main/resources` {#src-main-resources}
 
 The `src/main/resources` folder is used to store the resources that your mod uses, such as textures, models, and sounds.

--- a/reference/latest/src/main/java/com/example/docs/ExampleMod.java
+++ b/reference/latest/src/main/java/com/example/docs/ExampleMod.java
@@ -28,6 +28,10 @@ public class ExampleMod implements ModInitializer {
 	public static final String MOD_ID = "example-mod";
 	public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
 
+	public static Identifier id(String path) {
+		return Identifier.fromNamespaceAndPath(MOD_ID, path);
+	}
+
 	// #endregion entrypoint
 	// #region particle_register_main
 	// This DefaultParticleType gets called when you want to use your particle in code.
@@ -46,7 +50,7 @@ public class ExampleMod implements ModInitializer {
 
 		// #region particle_register_main
 		// Register our custom particle type in the mod initializer.
-		Registry.register(BuiltInRegistries.PARTICLE_TYPE, Identifier.fromNamespaceAndPath(ExampleMod.MOD_ID, "sparkle_particle"), SPARKLE_PARTICLE);
+		Registry.register(BuiltInRegistries.PARTICLE_TYPE, ExampleMod.id("sparkle_particle"), SPARKLE_PARTICLE);
 		// #endregion particle_register_main
 		// #region datagen_world_biome_modifications
 		// Spawns everywhere in the overworld


### PR DESCRIPTION
# Draft PR Description

## Why

Adds the `ExampleMod.id` helper requested in issue #606 so examples can create identifiers in the mod namespace without repeatedly spelling out `Identifier.fromNamespaceAndPath(ExampleMod.MOD_ID, path)`.

## What Changed

- Added `ExampleMod.id(String path)` to the reference mod entrypoint.
- Updated the `sparkle_particle` registration example to use the new helper.
- Documented the helper near the early `main` entrypoint example in the project structure guide.

## Verification

- Ran `git diff --check`.
- Confirmed the helper and documentation references with `rg`.

## Not Verified

- Full Gradle validation was not completed because the local machine has Java 17, while the repository Gradle plugin requires Java 21 or newer.

## Notes

This is an AI-assisted local draft. A human should review the patch, rerun validation under Java 21+, and submit the PR manually if acceptable.

