### PR TITLE
Document `fabric:false` resource condition

### DIFF
--- a/develop/resource-conditions.md
+++ b/develop/resource-conditions.md
@@ -35,6 +35,12 @@ Always succeeds:
 
 <<< @/reference/latest/src/main/generated/reports/example-mod/resource_condition_examples/true.json
 
+#### False {#false}
+
+Always fails:
+
+<<< @/reference/latest/src/main/generated/reports/example-mod/resource_condition_examples/false.json
+
 #### Not {#not}
 
 Inverts the load condition specified in `value`. For example, the following will fail:

--- a/reference/latest/build.gradle
+++ b/reference/latest/build.gradle
@@ -1,5 +1,5 @@
 def minecraftVersion = "26.1.2"
-def fabricApiVersion = "0.148.2+26.1.2"
+def fabricApiVersion = "0.151.0+26.1.2"
 
 // #region automatic_testing_game_test_2
 dependencies {

--- a/reference/latest/src/client/java/com/example/docs/datagen/internal/ExampleModResourceConditionProvider.java
+++ b/reference/latest/src/client/java/com/example/docs/datagen/internal/ExampleModResourceConditionProvider.java
@@ -25,6 +25,7 @@ public class ExampleModResourceConditionProvider extends ExampleModExampleProvid
 
 	private static void encodeResourceConditions(BiConsumer<String, JsonElement> consumer) {
 		acceptCondition(consumer, ResourceConditions.alwaysTrue());
+		acceptCondition(consumer, ResourceConditions.alwaysFalse());
 		acceptCondition(consumer, ResourceConditions.not(ResourceConditions.alwaysTrue()));
 		acceptCondition(consumer, ResourceConditions.or(ResourceConditions.alwaysTrue(), ResourceConditions.not(ResourceConditions.alwaysTrue())));
 		acceptCondition(consumer, ResourceConditions.and(ResourceConditions.alwaysTrue(), ResourceConditions.not(ResourceConditions.alwaysTrue())));

--- a/reference/latest/src/main/generated/reports/example-mod/resource_condition_examples/false.json
+++ b/reference/latest/src/main/generated/reports/example-mod/resource_condition_examples/false.json
@@ -1,0 +1,7 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:false"
+    }
+  ]
+}


### PR DESCRIPTION
Fabric API 0.151.0 introduces the `fabric:false` resource condition, a counterpart to `fabric:true` that never succeeds.