### PR TITLE
[26.1.2] No longer copy the created ItemStack in Custom Recipe Types

### DIFF
--- a/reference/latest/src/main/java/com/example/docs/recipe/UpgradingRecipe.java
+++ b/reference/latest/src/main/java/com/example/docs/recipe/UpgradingRecipe.java
@@ -49,7 +49,7 @@ public class UpgradingRecipe implements Recipe<UpgradingRecipeInput> {
 
 	@Override
 	public ItemStack assemble(UpgradingRecipeInput recipeInput) {
-		return this.result.create().copy();
+		return this.result.create();
 	}
 	// #endregion implementing
 


### PR DESCRIPTION
This is probably a remnant from 1.21.11 before ItemStackTemplate was added to the game.