### PR TITLE
Update Checkstyle report action to v3

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,7 @@ jobs:
       - run: ./gradlew runDatagen --stacktrace --warning-mode fail
         working-directory: ./reference
       - if: failure()
-        uses: FabricMCBot/publish-checkstyle-report@4627c82002aa370b6cb2a3140f34c7a8c55a5297
+        uses: FabricMCBot/publish-checkstyle-report@v3
         with:
           reports: reference/**/build/reports/checkstyle/*.xml
       # require clean working directory


### PR DESCRIPTION
The main change in the action update is the mandatory Node update. This change should be backported to all maintained versions.