### PR TITLE
Add section showcasing usage of `MixinIntrinsics.currentEnumOrdinal()` in the context of enum extensions.

### DIFF
--- a/develop/class-tweakers/enum-extension.md
+++ b/develop/class-tweakers/enum-extension.md
@@ -68,6 +68,16 @@ let's add a new `ConversionType` entry:
 
 <<< @/reference/latest/src/main/java/com/example/docs/mixin/class_tweakers/ConversionTypeMixin.java#enum_extension_abstract_method_impls_example_mixin
 
+### Accessing the Current Enum Ordinal {#accessing-current-enum-ordinal}
+
+Sometimes, you may need to get the ordinal of your added enum entry, such as to pass it to a constructor. To get it reliably while accounting for other mods,
+Mixin provides the `MixinIntrinsics.currentEnumOrdinal()` method.
+
+For example, let's use it to remain compatible while making a Mixin into `SpellcasterIllager.IllagerSpell`, where we can call `currentEnumOrdinal()` to ensure
+the id we pass to a constructor follows the Vanilla pattern of the id corresponding to the enum entry ordinal:
+
+<<< @/reference/latest/src/main/java/com/example/docs/mixin/class_tweakers/IllagerSpellMixin.java#enum_extension_current_enum_ordinal_example_mixin
+
 ## Making the Class Tweaker Entry {#making-the-class-tweaker-entry}
 
 If you are targeting a Minecraft enum, you can use a class tweaker entry to visibly modify the target enum in the decompiled source.

--- a/develop/class-tweakers/enum-extension.md
+++ b/develop/class-tweakers/enum-extension.md
@@ -70,13 +70,14 @@ let's add a new `ConversionType` entry:
 
 ### Accessing the Current Enum Ordinal {#accessing-current-enum-ordinal}
 
-Sometimes, you may need to get the ordinal of your added enum entry, such as to pass it to a constructor. To get it reliably while accounting for other mods,
-Mixin provides the `MixinIntrinsics.currentEnumOrdinal()` method.
+Sometimes, you may need to get the ordinal of your added enum entry, for example when passing it to a constructor. To do this,
+Mixin provides the `MixinIntrinsics.currentEnumOrdinal()` method, which returns the correct index while accounting for other mods' contributions.
 
-For example, let's use it to remain compatible while making a Mixin into `SpellcasterIllager.IllagerSpell`, where we can call `currentEnumOrdinal()` to ensure
-the id we pass to a constructor follows the Vanilla pattern of the id corresponding to the enum entry ordinal:
+As an example, let's make a mixin into vanilla's `IllagerSpell` and add a spell, whose ordinal gets passed as the first argument of the constructor:
 
 <<< @/reference/latest/src/main/java/com/example/docs/mixin/class_tweakers/IllagerSpellMixin.java#enum_extension_current_enum_ordinal_example_mixin
+
+Now, you can stay assured that `currentEnumOrdinal()` will return the correct index, even if another mod were to also extend this same enum.
 
 ## Making the Class Tweaker Entry {#making-the-class-tweaker-entry}
 

--- a/develop/class-tweakers/enum-extension.md
+++ b/develop/class-tweakers/enum-extension.md
@@ -70,7 +70,7 @@ let's add a new `ConversionType` entry:
 
 ### Accessing the Current Enum Ordinal {#accessing-current-enum-ordinal}
 
-Sometimes, you may need to get the ordinal of your added enum entry, for example when passing it to a constructor. To do this,
+You may need to get the ordinal of your added enum entry to pass it to a constructor. To do this,
 Mixin provides the `MixinIntrinsics.currentEnumOrdinal()` method, which returns the correct index while accounting for other mods' contributions.
 
 As an example, let's make a mixin into vanilla's `IllagerSpell` and add a spell, whose ordinal gets passed as the first argument of the constructor:

--- a/reference/latest/src/main/java/com/example/docs/mixin/class_tweakers/IllagerSpellMixin.java
+++ b/reference/latest/src/main/java/com/example/docs/mixin/class_tweakers/IllagerSpellMixin.java
@@ -1,0 +1,16 @@
+package com.example.docs.mixin.class_tweakers;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.MixinIntrinsics;
+import org.spongepowered.asm.mixin.Shadow;
+
+//#region enum_extension_current_enum_ordinal_example_mixin
+@Mixin(targets = "net.minecraft.world.entity.monster.illager.SpellcasterIllager$IllagerSpell")
+enum IllagerSpellMixin {
+	EXAMPLE_MOD_ILLAGER_SPELL(MixinIntrinsics.currentEnumOrdinal(), 0.8, 0.8, 0.2);
+
+	@Shadow
+	IllagerSpellMixin(final int id, final double red, final double green, final double blue) {
+	}
+}
+//#endregion enum_extension_current_enum_ordinal_example_mixin

--- a/reference/latest/src/main/resources/example-mod.mixins.json
+++ b/reference/latest/src/main/resources/example-mod.mixins.json
@@ -8,7 +8,8 @@
     "class_tweakers.FlowingFluidMixin",
     "class_tweakers.RecipeBookTypeMixin",
     "class_tweakers.RecipeCategoryMixin",
-    "class_tweakers.ConversionTypeMixin"
+    "class_tweakers.ConversionTypeMixin",
+    "class_tweakers.IllagerSpellMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This was suggested by @Patbox and I used the same Mixin target as them for the example.

The subsection is brief, but there isn't too much content to cover in the first place.

The `mixins.json` of the reference mod was also updated accordingly, however I found it mostly irrelevant to add the new example to the `.classtweaker` file entries, as the class tweaker part of this isn't anything special or new.

As with anything touching Mixin, the eyes of @LlamaLad7 would be greatly appreciated.