### PR TITLE
Note that mcsrc.dev supports all versions

### DIFF
--- a/develop/class-tweakers/access-widening.md
+++ b/develop/class-tweakers/access-widening.md
@@ -121,7 +121,6 @@ Manually writing access widener entries is time-consuming and prone to human err
 
 ### mcsrc.dev {#mcsrc-dev}
 
-Available for all versions with an [unobfuscated JAR](../migrating-mappings/index#whats-going-on-with-mappings), namely 1.21.11 and above,
 [mcsrc](https://mcsrc.dev) allows you to decompile and navigate Minecraft source in the browser and copy Mixin, access widener or access transformer targets to clipboard.
 
 To copy an access widener entry, first navigate to the class which you want to modify, and right-click on your target to open the popup menu.

--- a/versions/1.21.11/develop/class-tweakers/access-widening.md
+++ b/versions/1.21.11/develop/class-tweakers/access-widening.md
@@ -127,7 +127,6 @@ Manually writing access widener entries is time-consuming and prone to human err
 
 ### mcsrc.dev {#mcsrc-dev}
 
-Available for all versions with an [unobfuscated JAR](../migrating-mappings/index#whats-going-on-with-mappings) namely 1.21.11 and above,
 [mcsrc](https://mcsrc.dev) allows you to decompile and navigate Minecraft source in the browser and copy Mixin, access widener or access transformer targets to clipboard.
 The names of classes, methods and fields on [mcsrc](https://mcsrc.dev) will align with [Mojang Mappings](../migrating-mappings/index#mappings).
 


### PR DESCRIPTION
`mcsrc.dev` was recently updated to support unobfuscated versions, making this note unnecessary.