### PR TITLE
fix-#668 by using correct name in old versions and languages

### DIFF
--- a/versions/1.21.1/develop/automatic-testing.md
+++ b/versions/1.21.1/develop/automatic-testing.md
@@ -23,7 +23,7 @@ Since Minecraft modding relies on runtime byte-code modification tools such as M
 
 First, we need to add Fabric Loader JUnit to the development environment. Add the following to your dependencies block in your `build.gradle`:
 
-@[code lang=groovy transcludeWith=:::automatic-testing:1](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=automatic_testing_1](@/reference/build.gradle)
 
 Then, we need to tell Gradle to use Fabric Loader JUnit for testing. You can do so by adding the following code to your `build.gradle`:
 

--- a/versions/1.21.1/develop/data-generation/setup.md
+++ b/versions/1.21.1/develop/data-generation/setup.md
@@ -38,7 +38,7 @@ If datagen is enabled, you should have a "Data Generation" run configuration and
 
 First, we need to enable datagen in the `build.gradle` file.
 
-@[code lang=groovy transcludeWith=:::datagen-setup:configure](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=datagen_setup_configure](@/reference/build.gradle)
 
 Next, we need an entrypoint class. This is where our datagen starts. Place this somewhere in the `client` package - this example places it at `src/client/java/com/example/docs/datagen/ExampleModDataGenerator.java`.
 

--- a/versions/1.21.1/translated/de_de/develop/automatic-testing.md
+++ b/versions/1.21.1/translated/de_de/develop/automatic-testing.md
@@ -21,7 +21,7 @@ Da Minecraft Modding auf Laufzeit-Bytecode-Modifikationswerkzeuge wie Mixin ange
 
 Zuerst müssen wir Fabric Loader JUnit zu der Entwicklungsumgebung hinzufügen. Füge folgendes zu deinem Dependencies-Block in deiner `build.gradle`-Datei hinzu:
 
-@[code lang=groovy transcludeWith=:::automatic-testing:1](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=automatic_testing_1](@/reference/build.gradle)
 
 Dann müssen wir Gradle anweisen, Fabric Loader JUnit zum Testen zu verwenden. Du kannst dies tun, indem du den folgenden Code zu deiner `build.gradle`-Datei hinzufügst:
 

--- a/versions/1.21.1/translated/de_de/develop/data-generation/setup.md
+++ b/versions/1.21.1/translated/de_de/develop/data-generation/setup.md
@@ -36,7 +36,7 @@ Wenn die Datengenerierung aktiviert ist, solltest du eine "Data Generation" Lauf
 
 Zuerst müssen wir die Datengenerierung in der `build.Gradle`-Datei aktivieren.
 
-@[code lang=groovy transcludeWith=:::datagen-setup:configure](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=datagen_setup_configure](@/reference/build.gradle)
 
 Als nächstes, benötigen wir eine Klasse für den Einstiegspunkt. Dies ist dort, wo unsere Datengenerierung startet. Platziere diese irgendwo in dem `client` Packet - dieses Beispiel platziert diese in `src/client/java/com/example/docs/datagen/ExampleModDataGenerator.java`.
 

--- a/versions/1.21.1/translated/it_it/develop/automatic-testing.md
+++ b/versions/1.21.1/translated/it_it/develop/automatic-testing.md
@@ -21,7 +21,7 @@ Poiché il modding in Minecraft si affida a strumenti di modifica del byte-code 
 
 Anzitutto, dobbiamo aggiungere Fabric Loader JUnit all'ambiente di sviluppo. Aggiungi il seguente blocco di dipendenze al tuo `build.gradle`:
 
-@[code lang=groovy transcludeWith=:::automatic-testing:1](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=automatic_testing_1](@/reference/build.gradle)
 
 Poi, dobbiamo informare Gradle su come usare Fabric Loader JUnit per il testing. Puoi fare ciò aggiungendo il codice seguente al tuo `build.gradle`:
 

--- a/versions/1.21.1/translated/it_it/develop/data-generation/setup.md
+++ b/versions/1.21.1/translated/it_it/develop/data-generation/setup.md
@@ -36,7 +36,7 @@ Se la datagen è attiva, dovresti avere una configurazione di esecuzione "Data G
 
 Anzitutto, dobbiamo attivare la datagen nel file `build.gradle`.
 
-@[code lang=groovy transcludeWith=:::datagen-setup:configure](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=datagen_setup_configure](@/reference/build.gradle)
 
 Poi ci serve una classe entrypoint. È qui che comincia la nostra datagen. Mettila da qualche parte nel package `client` - questo esempio la inserisce in `src/client/java/com/example/docs/datagen/ExampleModDataGenerator.java`.
 

--- a/versions/1.21.1/translated/ru_ru/develop/automatic-testing.md
+++ b/versions/1.21.1/translated/ru_ru/develop/automatic-testing.md
@@ -21,7 +21,7 @@ authors:
 
 Сначала нам необходимо добавить Fabric Loader JUnit в среду разработки. Добавьте следующее в блок зависимостей в `build.gradle`:
 
-@[code lang=groovy transcludeWith=:::automatic-testing:1](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=automatic_testing_1](@/reference/build.gradle)
 
 Затем нам нужно указать Gradle использовать Fabric Loader JUnit для тестирования. Это можно сделать, добавив следующий код в `build.gradle`:
 

--- a/versions/1.21.10/develop/automatic-testing.md
+++ b/versions/1.21.10/develop/automatic-testing.md
@@ -17,7 +17,7 @@ Since Minecraft modding relies on runtime byte-code modification tools such as M
 
 First, we need to add Fabric Loader JUnit to the development environment. Add the following to your dependencies block in your `build.gradle`:
 
-@[code transcludeWith=:::automatic-testing:1](@/reference/build.gradle)
+@[code transcludeWith=automatic_testing_1](@/reference/build.gradle)
 
 Then, we need to tell Gradle to use Fabric Loader JUnit for testing. You can do so by adding the following code to your `build.gradle`:
 

--- a/versions/1.21.10/develop/data-generation/setup.md
+++ b/versions/1.21.10/develop/data-generation/setup.md
@@ -36,7 +36,7 @@ If datagen is enabled, you should have a "Data Generation" run configuration and
 
 First, we need to enable datagen in the `build.gradle` file.
 
-@[code transcludeWith=:::datagen-setup:configure](@/reference/build.gradle)
+@[code transcludeWith=datagen_setup_configure](@/reference/build.gradle)
 
 Next, we need an entrypoint class. This is where our datagen starts. Place this somewhere in the `client` package - this example places it at `src/client/java/com/example/docs/datagen/ExampleModDataGenerator.java`.
 

--- a/versions/1.21.10/translated/de_de/develop/automatic-testing.md
+++ b/versions/1.21.10/translated/de_de/develop/automatic-testing.md
@@ -21,7 +21,7 @@ Da Minecraft Modding auf Laufzeit-Bytecode-Modifikationswerkzeuge wie Mixin ange
 
 Zuerst müssen wir Fabric Loader JUnit zu der Entwicklungsumgebung hinzufügen. Füge folgendes zu deinem Dependencies-Block in deiner `build.gradle`-Datei hinzu:
 
-@[code lang=groovy transcludeWith=:::automatic-testing:1](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=automatic_testing_1](@/reference/build.gradle)
 
 Dann müssen wir Gradle anweisen, Fabric Loader JUnit zum Testen zu verwenden. Du kannst dies tun, indem du den folgenden Code zu deiner `build.gradle`-Datei hinzufügst:
 

--- a/versions/1.21.10/translated/de_de/develop/data-generation/setup.md
+++ b/versions/1.21.10/translated/de_de/develop/data-generation/setup.md
@@ -36,7 +36,7 @@ Wenn die Datengenerierung aktiviert ist, solltest du eine "Data Generation" Lauf
 
 Zuerst müssen wir die Datengenerierung in der `build.Gradle`-Datei aktivieren.
 
-@[code lang=groovy transcludeWith=:::datagen-setup:configure](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=datagen_setup_configure](@/reference/build.gradle)
 
 Als nächstes, benötigen wir eine Klasse für den Einstiegspunkt. Dies ist dort, wo unsere Datengenerierung startet. Platziere diese irgendwo in dem `client` Packet - dieses Beispiel platziert diese in `src/client/java/com/example/docs/datagen/ExampleModDataGenerator.java`.
 

--- a/versions/1.21.10/translated/it_it/develop/automatic-testing.md
+++ b/versions/1.21.10/translated/it_it/develop/automatic-testing.md
@@ -21,7 +21,7 @@ Poiché il modding in Minecraft si affida a strumenti di modifica del byte-code 
 
 Anzitutto, dobbiamo aggiungere Fabric Loader JUnit all'ambiente di sviluppo. Aggiungi il seguente blocco di dipendenze al tuo `build.gradle`:
 
-@[code lang=groovy transcludeWith=:::automatic-testing:1](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=automatic_testing_1](@/reference/build.gradle)
 
 Poi, dobbiamo informare Gradle su come usare Fabric Loader JUnit per il testing. Puoi fare ciò aggiungendo il codice seguente al tuo `build.gradle`:
 

--- a/versions/1.21.10/translated/it_it/develop/data-generation/setup.md
+++ b/versions/1.21.10/translated/it_it/develop/data-generation/setup.md
@@ -36,7 +36,7 @@ Se la datagen è attiva, dovresti avere una configurazione di esecuzione "Data G
 
 Anzitutto, dobbiamo attivare la datagen nel file `build.gradle`.
 
-@[code lang=groovy transcludeWith=:::datagen-setup:configure](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=datagen_setup_configure](@/reference/build.gradle)
 
 Poi ci serve una classe entrypoint. È qui che comincia la nostra datagen. Mettila da qualche parte nel package `client` - questo esempio la inserisce in `src/client/java/com/example/docs/datagen/ExampleModDataGenerator.java`.
 

--- a/versions/1.21.10/translated/ru_ru/develop/automatic-testing.md
+++ b/versions/1.21.10/translated/ru_ru/develop/automatic-testing.md
@@ -21,7 +21,7 @@ authors:
 
 Сначала нам необходимо добавить Fabric Loader JUnit в среду разработки. Добавьте следующее в блок зависимостей в `build.gradle`:
 
-@[code lang=groovy transcludeWith=:::automatic-testing:1](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=automatic_testing_1](@/reference/build.gradle)
 
 Затем нам нужно указать Gradle использовать Fabric Loader JUnit для тестирования. Это можно сделать, добавив следующий код в `build.gradle`:
 

--- a/versions/1.21.10/translated/uk_ua/develop/automatic-testing.md
+++ b/versions/1.21.10/translated/uk_ua/develop/automatic-testing.md
@@ -21,7 +21,7 @@ authors:
 
 По-перше, нам потрібно додати Fabric Loader JUnit до середовища розробки. Додайте наступне до блоку залежностей у вашому `build.gradle`:
 
-@[code lang=groovy transcludeWith=:::automatic-testing:1](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=automatic_testing_1](@/reference/build.gradle)
 
 Потім нам потрібно сказати Gradle використовувати Fabric Loader JUnit для тестування. Ви можете зробити це, додавши наступний код до свого `build.gradle`:
 

--- a/versions/1.21.10/translated/uk_ua/develop/data-generation/setup.md
+++ b/versions/1.21.10/translated/uk_ua/develop/data-generation/setup.md
@@ -36,7 +36,7 @@ authors-nogithub:
 
 По-перше, нам потрібно ввімкнути datagen у файлі `build.gradle`.
 
-@[code lang=groovy transcludeWith=:::datagen-setup:configure](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=datagen_setup_configure](@/reference/build.gradle)
 
 Далі нам потрібен клас точки входу. Ось де починається наш datagen. Розмістіть це десь у пакеті `client` - у цьому прикладі це розміщено в `src/client/java/com/example/docs/datagen/ExampleModDataGenerator.java`.
 

--- a/versions/1.21.10/translated/zh_cn/develop/automatic-testing.md
+++ b/versions/1.21.10/translated/zh_cn/develop/automatic-testing.md
@@ -21,7 +21,7 @@ authors:
 
 首先，我们需要将Fabric Loader JUnit添加到开发环境。 将以下依赖添加到你的`build.gradle`：
 
-@[code lang=groovy transcludeWith=:::automatic-testing:1](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=automatic_testing_1](@/reference/build.gradle)
 
 然后，我们需要告诉Gradle使用Fabric Loader JUnit来测试。 你可以通过将以下代码添加到`build.gradle`来做到这件事：
 

--- a/versions/1.21.10/translated/zh_cn/develop/data-generation/setup.md
+++ b/versions/1.21.10/translated/zh_cn/develop/data-generation/setup.md
@@ -36,7 +36,7 @@ authors-nogithub:
 
 首先，我们需要在 `build.gradle` 文件中启用 datagen。
 
-@[code lang=groovy transcludeWith=:::datagen-setup:configure](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=datagen_setup_configure](@/reference/build.gradle)
 
 接下来，我们需要一个入口点类。 这是我们的 datagen 的起点。 将其放在 `client` 包中的某个位置——本示例将其放在 `src/client/java/com/example/docs/datagen/ExampleModDataGenerator.java`。
 

--- a/versions/1.21.11/develop/automatic-testing.md
+++ b/versions/1.21.11/develop/automatic-testing.md
@@ -17,7 +17,7 @@ Since Minecraft modding relies on runtime byte-code modification tools such as M
 
 First, we need to add Fabric Loader JUnit to the development environment. Add the following to your dependencies block in your `build.gradle`:
 
-@[code transcludeWith=:::automatic-testing:1](@/reference/build.gradle)
+@[code transcludeWith=automatic_testing_1](@/reference/build.gradle)
 
 Then, we need to tell Gradle to use Fabric Loader JUnit for testing. You can do so by adding the following code to your `build.gradle`:
 

--- a/versions/1.21.11/develop/data-generation/setup.md
+++ b/versions/1.21.11/develop/data-generation/setup.md
@@ -38,7 +38,7 @@ If datagen is enabled, you should have a "Data Generation" run configuration and
 
 First, we need to enable datagen in the `build.gradle` file.
 
-@[code transcludeWith=:::datagen-setup:configure](@/reference/build.gradle)
+@[code transcludeWith=datagen_setup_configure](@/reference/build.gradle)
 
 Next, we need an entrypoint class. This is where our datagen starts. Place this somewhere in the `client` package - this example places it at `src/client/java/com/example/docs/datagen/ExampleModDataGenerator.java`.
 

--- a/versions/1.21.11/translated/de_de/develop/automatic-testing.md
+++ b/versions/1.21.11/translated/de_de/develop/automatic-testing.md
@@ -17,7 +17,7 @@ Da Minecraft Modding auf Laufzeit-Bytecode-Modifikationswerkzeuge wie Mixin ange
 
 Zuerst müssen wir Fabric Loader JUnit zu der Entwicklungsumgebung hinzufügen. Füge folgendes zu deinem Dependencies-Block in deiner `build.gradle`-Datei hinzu:
 
-@[code transcludeWith=:::automatic-testing:1](@/reference/build.gradle)
+@[code transcludeWith=automatic_testing_1](@/reference/build.gradle)
 
 Dann müssen wir Gradle anweisen, Fabric Loader JUnit zum Testen zu verwenden. Du kannst dies tun, indem du den folgenden Code zu deiner `build.gradle`-Datei hinzufügst:
 

--- a/versions/1.21.11/translated/de_de/develop/data-generation/setup.md
+++ b/versions/1.21.11/translated/de_de/develop/data-generation/setup.md
@@ -38,7 +38,7 @@ Wenn der Datengenerator aktiviert ist, solltest du eine "Data Generation" Laufko
 
 Zuerst müssen wir den Datengenerator in der Datei `build.gradle` aktivieren.
 
-@[code transcludeWith=:::datagen-setup:configure](@/reference/build.gradle)
+@[code transcludeWith=datagen_setup_configure](@/reference/build.gradle)
 
 Als nächstes, benötigen wir eine Klasse für den Einstiegspunkt. Dies ist dort, wo unser Datengenerator startet. Platziere diese irgendwo in dem `client` Packet - dieses Beispiel platziert diese in `src/client/java/com/example/docs/datagen/ExampleModDataGenerator.java`.
 

--- a/versions/1.21.11/translated/it_it/develop/automatic-testing.md
+++ b/versions/1.21.11/translated/it_it/develop/automatic-testing.md
@@ -17,7 +17,7 @@ Poiché il modding in Minecraft si affida a strumenti di modifica del byte-code 
 
 Anzitutto, dobbiamo aggiungere Fabric Loader JUnit all'ambiente di sviluppo. Aggiungi il seguente blocco di dipendenze al tuo `build.gradle`:
 
-@[code transcludeWith=:::automatic-testing:1](@/reference/build.gradle)
+@[code transcludeWith=automatic_testing_1](@/reference/build.gradle)
 
 Poi, dobbiamo informare Gradle su come usare Fabric Loader JUnit per il testing. Puoi fare ciò aggiungendo il codice seguente al tuo `build.gradle`:
 

--- a/versions/1.21.11/translated/it_it/develop/data-generation/setup.md
+++ b/versions/1.21.11/translated/it_it/develop/data-generation/setup.md
@@ -38,7 +38,7 @@ Se la datagen è attiva, dovresti avere una configurazione di esecuzione "Data G
 
 Anzitutto, dobbiamo attivare la datagen nel file `build.gradle`.
 
-@[code transcludeWith=:::datagen-setup:configure](@/reference/build.gradle)
+@[code transcludeWith=datagen_setup_configure](@/reference/build.gradle)
 
 Poi ci serve una classe entrypoint. È qui che comincia la nostra datagen. Mettila da qualche parte nel package `client` - questo esempio la inserisce in `src/client/java/com/example/docs/datagen/ExampleModDataGenerator.java`.
 

--- a/versions/1.21.11/translated/uk_ua/develop/automatic-testing.md
+++ b/versions/1.21.11/translated/uk_ua/develop/automatic-testing.md
@@ -17,7 +17,7 @@ authors:
 
 По-перше, нам потрібно додати Fabric Loader JUnit до середовища розробки. Додайте наступне до блока залежностей у вашому `build.gradle`:
 
-@[code transcludeWith=:::automatic-testing:1](@/reference/build.gradle)
+@[code transcludeWith=automatic_testing_1](@/reference/build.gradle)
 
 Потім нам потрібно сказати Gradle використовувати Fabric Loader JUnit для тестування. Ви можете зробити це, додавши наступний код до свого `build.gradle`:
 

--- a/versions/1.21.11/translated/uk_ua/develop/data-generation/setup.md
+++ b/versions/1.21.11/translated/uk_ua/develop/data-generation/setup.md
@@ -38,7 +38,7 @@ authors-nogithub:
 
 По-перше, нам потрібно ввімкнути datagen у файлі `build.gradle`.
 
-@[code transcludeWith=:::datagen-setup:configure](@/reference/build.gradle)
+@[code transcludeWith=datagen_setup_configure](@/reference/build.gradle)
 
 Далі нам потрібен клас точки входу. Ось де починається наша генерація даних. Розмістіть це десь у пакеті `client` — у цьому прикладі це розміщено в `src/client/java/com/example/docs/datagen/ExampleModDataGenerator.java`.
 

--- a/versions/1.21.11/translated/zh_cn/develop/automatic-testing.md
+++ b/versions/1.21.11/translated/zh_cn/develop/automatic-testing.md
@@ -17,7 +17,7 @@ authors:
 
 首先，我们需要将 Fabric Loader JUnit 添加到开发环境。 将以下依赖添加到你的 `build.gradle`：
 
-@[code transcludeWith=:::automatic-testing:1](@/reference/build.gradle)
+@[code transcludeWith=automatic_testing_1](@/reference/build.gradle)
 
 然后，我们需要告诉 Gradle 使用 Fabric Loader JUnit 来测试。 你可以通过将以下代码添加到 `build.gradle` 来做到这件事：
 

--- a/versions/1.21.11/translated/zh_cn/develop/data-generation/setup.md
+++ b/versions/1.21.11/translated/zh_cn/develop/data-generation/setup.md
@@ -38,7 +38,7 @@ authors-nogithub:
 
 首先，我们需要在 `build.gradle` 文件中启用 datagen。
 
-@[code transcludeWith=:::datagen-setup:configure](@/reference/build.gradle)
+@[code transcludeWith=datagen_setup_configure](@/reference/build.gradle)
 
 接下来，我们需要一个入口点类。 这是我们的数据生成的起点。 将其放在 `client` 包中的某个位置——本示例将其放在 `src/client/java/com/example/docs/datagen/ExampleModDataGenerator.java`。
 

--- a/versions/1.21.4/develop/automatic-testing.md
+++ b/versions/1.21.4/develop/automatic-testing.md
@@ -17,7 +17,7 @@ Since Minecraft modding relies on runtime byte-code modification tools such as M
 
 First, we need to add Fabric Loader JUnit to the development environment. Add the following to your dependencies block in your `build.gradle`:
 
-@[code lang=groovy transcludeWith=:::automatic-testing:1](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=automatic_testing_1](@/reference/build.gradle)
 
 Then, we need to tell Gradle to use Fabric Loader JUnit for testing. You can do so by adding the following code to your `build.gradle`:
 

--- a/versions/1.21.4/develop/data-generation/setup.md
+++ b/versions/1.21.4/develop/data-generation/setup.md
@@ -36,7 +36,7 @@ If datagen is enabled, you should have a "Data Generation" run configuration and
 
 First, we need to enable datagen in the `build.gradle` file.
 
-@[code lang=groovy transcludeWith=:::datagen-setup:configure](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=datagen_setup_configure](@/reference/build.gradle)
 
 Next, we need an entrypoint class. This is where our datagen starts. Place this somewhere in the `client` package - this example places it at `src/client/java/com/example/docs/datagen/FabricDocsReferenceDataGenerator.java`.
 

--- a/versions/1.21.4/translated/de_de/develop/automatic-testing.md
+++ b/versions/1.21.4/translated/de_de/develop/automatic-testing.md
@@ -21,7 +21,7 @@ Da Minecraft Modding auf Laufzeit-Bytecode-Modifikationswerkzeuge wie Mixin ange
 
 Zuerst müssen wir Fabric Loader JUnit zu der Entwicklungsumgebung hinzufügen. Füge folgendes zu deinem Dependencies-Block in deiner `build.gradle`-Datei hinzu:
 
-@[code lang=groovy transcludeWith=:::automatic-testing:1](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=automatic_testing_1](@/reference/build.gradle)
 
 Dann müssen wir Gradle anweisen, Fabric Loader JUnit zum Testen zu verwenden. Du kannst dies tun, indem du den folgenden Code zu deiner `build.gradle`-Datei hinzufügst:
 

--- a/versions/1.21.4/translated/de_de/develop/data-generation/setup.md
+++ b/versions/1.21.4/translated/de_de/develop/data-generation/setup.md
@@ -36,7 +36,7 @@ Wenn die Datengenerierung aktiviert ist, solltest du eine "Data Generation" Lauf
 
 Zuerst müssen wir die Datengenerierung in der `build.Gradle`-Datei aktivieren.
 
-@[code lang=groovy transcludeWith=:::datagen-setup:configure](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=datagen_setup_configure](@/reference/build.gradle)
 
 Als nächstes, benötigen wir eine Klasse für den Einstiegspunkt. Dies ist dort, wo unsere Datengenerierung startet. Platziere diese irgendwo in dem `client` Packet - dieses Beispiel platziert diese in `src/client/java/com/example/docs/datagen/FabricDocsReferenceDataGenerator.java`.
 

--- a/versions/1.21.4/translated/it_it/develop/automatic-testing.md
+++ b/versions/1.21.4/translated/it_it/develop/automatic-testing.md
@@ -21,7 +21,7 @@ Poiché il modding in Minecraft si affida a strumenti di modifica del byte-code 
 
 Anzitutto, dobbiamo aggiungere Fabric Loader JUnit all'ambiente di sviluppo. Aggiungi il seguente blocco di dipendenze al tuo `build.gradle`:
 
-@[code lang=groovy transcludeWith=:::automatic-testing:1](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=automatic_testing_1](@/reference/build.gradle)
 
 Poi, dobbiamo informare Gradle su come usare Fabric Loader JUnit per il testing. Puoi fare ciò aggiungendo il codice seguente al tuo `build.gradle`:
 

--- a/versions/1.21.4/translated/it_it/develop/data-generation/setup.md
+++ b/versions/1.21.4/translated/it_it/develop/data-generation/setup.md
@@ -36,7 +36,7 @@ Se la datagen è attiva, dovresti avere una configurazione di esecuzione "Data G
 
 Anzitutto, dobbiamo attivare la datagen nel file `build.gradle`.
 
-@[code lang=groovy transcludeWith=:::datagen-setup:configure](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=datagen_setup_configure](@/reference/build.gradle)
 
 Poi ci serve una classe entrypoint. È qui che comincia la nostra datagen. Mettila da qualche parte nel package `client` - questo esempio la inserisce in `src/client/java/com/example/docs/datagen/FabricDocsReferenceDataGenerator.java`.
 

--- a/versions/1.21.4/translated/ru_ru/develop/automatic-testing.md
+++ b/versions/1.21.4/translated/ru_ru/develop/automatic-testing.md
@@ -21,7 +21,7 @@ authors:
 
 Сначала нам необходимо добавить Fabric Loader JUnit в среду разработки. Добавьте следующее в блок зависимостей в `build.gradle`:
 
-@[code lang=groovy transcludeWith=:::automatic-testing:1](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=automatic_testing_1](@/reference/build.gradle)
 
 Затем нам нужно указать Gradle использовать Fabric Loader JUnit для тестирования. Это можно сделать, добавив следующий код в `build.gradle`:
 

--- a/versions/1.21.4/translated/uk_ua/develop/automatic-testing.md
+++ b/versions/1.21.4/translated/uk_ua/develop/automatic-testing.md
@@ -21,7 +21,7 @@ authors:
 
 По-перше, нам потрібно додати Fabric Loader JUnit до середовища розробки. Додайте наступне до блоку залежностей у вашому `build.gradle`:
 
-@[code lang=groovy transcludeWith=:::automatic-testing:1](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=automatic_testing_1](@/reference/build.gradle)
 
 Потім нам потрібно сказати Gradle використовувати Fabric Loader JUnit для тестування. Ви можете зробити це, додавши наступний код до свого `build.gradle`:
 

--- a/versions/1.21.4/translated/uk_ua/develop/data-generation/setup.md
+++ b/versions/1.21.4/translated/uk_ua/develop/data-generation/setup.md
@@ -36,7 +36,7 @@ authors-nogithub:
 
 По-перше, нам потрібно ввімкнути datagen у файлі `build.gradle`.
 
-@[code lang=groovy transcludeWith=:::datagen-setup:configure](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=datagen_setup_configure](@/reference/build.gradle)
 
 Далі нам потрібен клас точки входу. Ось де починається наш datagen. Розмістіть це десь у пакеті `client` - у цьому прикладі це розміщено в `src/client/java/com/example/docs/datagen/FabricDocsReferenceDataGenerator.java`.
 

--- a/versions/1.21.4/translated/zh_cn/develop/automatic-testing.md
+++ b/versions/1.21.4/translated/zh_cn/develop/automatic-testing.md
@@ -21,7 +21,7 @@ authors:
 
 首先，我们需要将Fabric Loader JUnit添加到开发环境。 将以下依赖添加到你的`build.gradle`：
 
-@[code lang=groovy transcludeWith=:::automatic-testing:1](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=automatic_testing_1](@/reference/build.gradle)
 
 然后，我们需要告诉Gradle使用Fabric Loader JUnit来测试。 你可以通过将以下代码添加到`build.gradle`来做到这件事：
 

--- a/versions/1.21.4/translated/zh_cn/develop/data-generation/setup.md
+++ b/versions/1.21.4/translated/zh_cn/develop/data-generation/setup.md
@@ -36,7 +36,7 @@ authors-nogithub:
 
 首先，我们需要在 `build.gradle` 文件中启用 datagen。
 
-@[code lang=groovy transcludeWith=:::datagen-setup:configure](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=datagen_setup_configure](@/reference/build.gradle)
 
 接下来，我们需要一个入口点类。 这是我们的 datagen 的起点。 将其放在 `client` 包中的某个位置——本示例将其放在 `src/client/java/com/example/docs/datagen/FabricDocsReferenceDataGenerator.java`。
 

--- a/versions/1.21.8/develop/automatic-testing.md
+++ b/versions/1.21.8/develop/automatic-testing.md
@@ -17,7 +17,7 @@ Since Minecraft modding relies on runtime byte-code modification tools such as M
 
 First, we need to add Fabric Loader JUnit to the development environment. Add the following to your dependencies block in your `build.gradle`:
 
-@[code lang=groovy transcludeWith=:::automatic-testing:1](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=automatic_testing_1](@/reference/build.gradle)
 
 Then, we need to tell Gradle to use Fabric Loader JUnit for testing. You can do so by adding the following code to your `build.gradle`:
 

--- a/versions/1.21.8/develop/data-generation/setup.md
+++ b/versions/1.21.8/develop/data-generation/setup.md
@@ -36,7 +36,7 @@ If datagen is enabled, you should have a "Data Generation" run configuration and
 
 First, we need to enable datagen in the `build.gradle` file.
 
-@[code lang=groovy transcludeWith=:::datagen-setup:configure](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=datagen_setup_configure](@/reference/build.gradle)
 
 Next, we need an entrypoint class. This is where our datagen starts. Place this somewhere in the `client` package - this example places it at `src/client/java/com/example/docs/datagen/FabricDocsReferenceDataGenerator.java`.
 

--- a/versions/1.21.8/translated/de_de/develop/automatic-testing.md
+++ b/versions/1.21.8/translated/de_de/develop/automatic-testing.md
@@ -21,7 +21,7 @@ Da Minecraft Modding auf Laufzeit-Bytecode-Modifikationswerkzeuge wie Mixin ange
 
 Zuerst müssen wir Fabric Loader JUnit zu der Entwicklungsumgebung hinzufügen. Füge folgendes zu deinem Dependencies-Block in deiner `build.gradle`-Datei hinzu:
 
-@[code lang=groovy transcludeWith=:::automatic-testing:1](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=automatic_testing_1](@/reference/build.gradle)
 
 Dann müssen wir Gradle anweisen, Fabric Loader JUnit zum Testen zu verwenden. Du kannst dies tun, indem du den folgenden Code zu deiner `build.gradle`-Datei hinzufügst:
 

--- a/versions/1.21.8/translated/de_de/develop/data-generation/setup.md
+++ b/versions/1.21.8/translated/de_de/develop/data-generation/setup.md
@@ -36,7 +36,7 @@ Wenn die Datengenerierung aktiviert ist, solltest du eine "Data Generation" Lauf
 
 Zuerst müssen wir die Datengenerierung in der `build.Gradle`-Datei aktivieren.
 
-@[code lang=groovy transcludeWith=:::datagen-setup:configure](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=datagen_setup_configure](@/reference/build.gradle)
 
 Als nächstes, benötigen wir eine Klasse für den Einstiegspunkt. Dies ist dort, wo unsere Datengenerierung startet. Platziere diese irgendwo in dem `client` Packet - dieses Beispiel platziert diese in `src/client/java/com/example/docs/datagen/FabricDocsReferenceDataGenerator.java`.
 

--- a/versions/1.21.8/translated/it_it/develop/automatic-testing.md
+++ b/versions/1.21.8/translated/it_it/develop/automatic-testing.md
@@ -21,7 +21,7 @@ Poiché il modding in Minecraft si affida a strumenti di modifica del byte-code 
 
 Anzitutto, dobbiamo aggiungere Fabric Loader JUnit all'ambiente di sviluppo. Aggiungi il seguente blocco di dipendenze al tuo `build.gradle`:
 
-@[code lang=groovy transcludeWith=:::automatic-testing:1](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=automatic_testing_1](@/reference/build.gradle)
 
 Poi, dobbiamo informare Gradle su come usare Fabric Loader JUnit per il testing. Puoi fare ciò aggiungendo il codice seguente al tuo `build.gradle`:
 

--- a/versions/1.21.8/translated/it_it/develop/data-generation/setup.md
+++ b/versions/1.21.8/translated/it_it/develop/data-generation/setup.md
@@ -36,7 +36,7 @@ Se la datagen è attiva, dovresti avere una configurazione di esecuzione "Data G
 
 Anzitutto, dobbiamo attivare la datagen nel file `build.gradle`.
 
-@[code lang=groovy transcludeWith=:::datagen-setup:configure](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=datagen_setup_configure](@/reference/build.gradle)
 
 Poi ci serve una classe entrypoint. È qui che comincia la nostra datagen. Mettila da qualche parte nel package `client` - questo esempio la inserisce in `src/client/java/com/example/docs/datagen/FabricDocsReferenceDataGenerator.java`.
 

--- a/versions/1.21.8/translated/ru_ru/develop/automatic-testing.md
+++ b/versions/1.21.8/translated/ru_ru/develop/automatic-testing.md
@@ -21,7 +21,7 @@ authors:
 
 Сначала нам необходимо добавить Fabric Loader JUnit в среду разработки. Добавьте следующее в блок зависимостей в `build.gradle`:
 
-@[code lang=groovy transcludeWith=:::automatic-testing:1](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=automatic_testing_1](@/reference/build.gradle)
 
 Затем нам нужно указать Gradle использовать Fabric Loader JUnit для тестирования. Это можно сделать, добавив следующий код в `build.gradle`:
 

--- a/versions/1.21.8/translated/uk_ua/develop/automatic-testing.md
+++ b/versions/1.21.8/translated/uk_ua/develop/automatic-testing.md
@@ -21,7 +21,7 @@ authors:
 
 По-перше, нам потрібно додати Fabric Loader JUnit до середовища розробки. Додайте наступне до блоку залежностей у вашому `build.gradle`:
 
-@[code lang=groovy transcludeWith=:::automatic-testing:1](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=automatic_testing_1](@/reference/build.gradle)
 
 Потім нам потрібно сказати Gradle використовувати Fabric Loader JUnit для тестування. Ви можете зробити це, додавши наступний код до свого `build.gradle`:
 

--- a/versions/1.21.8/translated/uk_ua/develop/data-generation/setup.md
+++ b/versions/1.21.8/translated/uk_ua/develop/data-generation/setup.md
@@ -36,7 +36,7 @@ authors-nogithub:
 
 По-перше, нам потрібно ввімкнути datagen у файлі `build.gradle`.
 
-@[code lang=groovy transcludeWith=:::datagen-setup:configure](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=datagen_setup_configure](@/reference/build.gradle)
 
 Далі нам потрібен клас точки входу. Ось де починається наш datagen. Розмістіть це десь у пакеті `client` - у цьому прикладі це розміщено в `src/client/java/com/example/docs/datagen/FabricDocsReferenceDataGenerator.java`.
 

--- a/versions/1.21.8/translated/zh_cn/develop/automatic-testing.md
+++ b/versions/1.21.8/translated/zh_cn/develop/automatic-testing.md
@@ -21,7 +21,7 @@ authors:
 
 首先，我们需要将Fabric Loader JUnit添加到开发环境。 将以下依赖添加到你的`build.gradle`：
 
-@[code lang=groovy transcludeWith=:::automatic-testing:1](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=automatic_testing_1](@/reference/build.gradle)
 
 然后，我们需要告诉Gradle使用Fabric Loader JUnit来测试。 你可以通过将以下代码添加到`build.gradle`来做到这件事：
 

--- a/versions/1.21.8/translated/zh_cn/develop/data-generation/setup.md
+++ b/versions/1.21.8/translated/zh_cn/develop/data-generation/setup.md
@@ -36,7 +36,7 @@ authors-nogithub:
 
 首先，我们需要在 `build.gradle` 文件中启用 datagen。
 
-@[code lang=groovy transcludeWith=:::datagen-setup:configure](@/reference/build.gradle)
+@[code lang=groovy transcludeWith=datagen_setup_configure](@/reference/build.gradle)
 
 接下来，我们需要一个入口点类。 这是我们的 datagen 的起点。 将其放在 `client` 包中的某个位置——本示例将其放在 `src/client/java/com/example/docs/datagen/FabricDocsReferenceDataGenerator.java`。
 


### PR DESCRIPTION
i'd also suggest moving those references to version specific build.gradle files.