### PR TITLE
Remove use of GLFW in KeyMapping page

### DIFF
--- a/develop/key-mappings.md
+++ b/develop/key-mappings.md
@@ -32,11 +32,11 @@ our key mapping at the same time.
 
 ::: info
 
-Note that the names of the key tokens (`GLFW.GLFW_KEY_*`) assume
+Note that the names of the key tokens (`InputConstants.KEY_*`) assume
 a [standard US layout](https://upload.wikimedia.org/wikipedia/commons/d/da/KB_United_States.svg).
 
 This means that if you're using an AZERTY layout, pressing on <kbd>A</kbd> would yield
-`GLFW.GLFW_KEY_Q`.
+`InputConstants.KEY_Q`.
 
 :::
 

--- a/reference/1.21.11/src/client/java/com/example/docs/keymapping/ExampleModKeyMappingsClient.java
+++ b/reference/1.21.11/src/client/java/com/example/docs/keymapping/ExampleModKeyMappingsClient.java
@@ -1,7 +1,6 @@
 package com.example.docs.keymapping;
 
 import com.mojang.blaze3d.platform.InputConstants;
-import org.lwjgl.glfw.GLFW;
 
 import net.minecraft.client.KeyMapping;
 import net.minecraft.network.chat.Component;
@@ -25,7 +24,7 @@ public class ExampleModKeyMappingsClient implements ClientModInitializer {
 		new KeyMapping(
 			"key.example-mod.send_to_chat", // The translation key for the key mapping.
 			InputConstants.Type.KEYSYM, // // The type of the keybinding; KEYSYM for keyboard, MOUSE for mouse.
-			GLFW.GLFW_KEY_J, // The GLFW keycode of the key.
+			InputConstants.KEY_J, // The keycode of the key.
 			CATEGORY // The category of the mapping.
 		));
 	// :::key_mapping

--- a/reference/26.1.2/src/client/java/com/example/docs/keymapping/ExampleModKeyMappingsClient.java
+++ b/reference/26.1.2/src/client/java/com/example/docs/keymapping/ExampleModKeyMappingsClient.java
@@ -1,7 +1,6 @@
 package com.example.docs.keymapping;
 
 import com.mojang.blaze3d.platform.InputConstants;
-import org.lwjgl.glfw.GLFW;
 
 import net.minecraft.client.KeyMapping;
 import net.minecraft.network.chat.Component;
@@ -25,7 +24,7 @@ public class ExampleModKeyMappingsClient implements ClientModInitializer {
 		new KeyMapping(
 				"key.example-mod.send_to_chat", // The translation key for the key mapping.
 				InputConstants.Type.KEYSYM, // The type of the keybinding; KEYSYM for keyboard, MOUSE for mouse.
-				GLFW.GLFW_KEY_J, // The GLFW keycode of the key.
+				InputConstants.KEY_J, // The keycode of the key.
 				this.CATEGORY // The category of the mapping.
 		));
 	// #endregion key_mapping

--- a/reference/latest/src/client/java/com/example/docs/keymapping/ExampleModKeyMappingsClient.java
+++ b/reference/latest/src/client/java/com/example/docs/keymapping/ExampleModKeyMappingsClient.java
@@ -1,7 +1,6 @@
 package com.example.docs.keymapping;
 
 import com.mojang.blaze3d.platform.InputConstants;
-import org.lwjgl.glfw.GLFW;
 
 import net.minecraft.client.KeyMapping;
 import net.minecraft.network.chat.Component;
@@ -25,7 +24,7 @@ public class ExampleModKeyMappingsClient implements ClientModInitializer {
 		new KeyMapping(
 				"key.example-mod.send_to_chat", // The translation key for the key mapping.
 				InputConstants.Type.KEYSYM, // The type of the keybinding; KEYSYM for keyboard, MOUSE for mouse.
-				GLFW.GLFW_KEY_J, // The GLFW keycode of the key.
+				InputConstants.KEY_J, // The keycode of the key.
 				this.CATEGORY // The category of the mapping.
 		));
 	// #endregion key_mapping

--- a/translated/de_de/develop/key-mappings.md
+++ b/translated/de_de/develop/key-mappings.md
@@ -30,10 +30,10 @@ gleichzeitig unsere Tastenbelegung zu registrieren.
 
 ::: info
 
-Beachte, dass die Namen der Tastentoken (`GLFW.GLFW_KEY_*`) von einem
+Beachte, dass die Namen der Tastentoken (`InputConstants.KEY_*`) von einem
 [Standard-US-Layout](https://upload.wikimedia.org/wikipedia/commons/d/da/KB_United_States.svg) ausgehen.
 
-Das bedeutet, dass bei Verwendung eines AZERTY-Layouts das Drücken von <kbd>A</kbd> zu `GLFW.GLFW_KEY_Q` führt.
+Das bedeutet, dass bei Verwendung eines AZERTY-Layouts das Drücken von <kbd>A</kbd> zu `InputConstants.KEY_Q` führt.
 
 :::
 

--- a/translated/ru_ru/develop/key-mappings.md
+++ b/translated/ru_ru/develop/key-mappings.md
@@ -29,9 +29,9 @@ Minecraft обрабатывает ввод пользователя с пери
 
 ::: info
 
-Обратите внимание, что названия токенов клавиш (`GLFW.GLFW_KEY_*`) подразумевают [стандартную раскладку США](https://upload.wikimedia.org/wikipedia/commons/d/da/KB_United_States.svg).
+Обратите внимание, что названия токенов клавиш (`InputConstants.KEY_*`) подразумевают [стандартную раскладку США](https://upload.wikimedia.org/wikipedia/commons/d/da/KB_United_States.svg).
 
-Это означает, что если вы используете раскладку AZERTY, нажатие на клавишу <kbd>A</kbd> вернет значение `GLFW.GLFW_KEY_Q`.
+Это означает, что если вы используете раскладку AZERTY, нажатие на клавишу <kbd>A</kbd> вернет значение `InputConstants.KEY_Q`.
 
 :::
 

--- a/translated/uk_ua/develop/key-mappings.md
+++ b/translated/uk_ua/develop/key-mappings.md
@@ -29,10 +29,10 @@ Minecraft обробляє введення користувачами з пер
 
 ::: info
 
-Зауважте, що назви маркерів ключів (`GLFW.GLFW_KEY_*`) припускаються [стандартний макет США](https://upload.wikimedia.org/wikipedia/commons/d/da/KB_United_States.svg).
+Зауважте, що назви маркерів ключів (`InputConstants.KEY_*`) припускаються [стандартний макет США](https://upload.wikimedia.org/wikipedia/commons/d/da/KB_United_States.svg).
 
 Це означає, що якщо ви використовуєте макет AZERTY, натискання <kbd>A</kbd> призведе до
-`GLFW.GLFW_KEY_Q`.
+`InputConstants.KEY_Q`.
 
 :::
 

--- a/translated/zh_cn/develop/key-mappings.md
+++ b/translated/zh_cn/develop/key-mappings.md
@@ -29,9 +29,9 @@ Minecraft 使用按键映射来处理来自像键盘、鼠标之类的外围设�
 
 ::: info
 
-注意按键的名称（`GLFW.GLFW_KEY_*`）会假定我们使用的是[标准美式布局](https://upload.wikimedia.org/wikipedia/commons/d/da/KB_United_States.svg)。
+注意按键的名称（`InputConstants.KEY_*`）会假定我们使用的是[标准美式布局](https://upload.wikimedia.org/wikipedia/commons/d/da/KB_United_States.svg)。
 
-这意味着如果使用的是 AZERTY 布局，按下 <kbd>A</kbd> 可能会产生 `GLFW.GLFW_KEY_Q`。
+这意味着如果使用的是 AZERTY 布局，按下 <kbd>A</kbd> 可能会产生 `InputConstants.KEY_Q`。
 
 :::
 

--- a/versions/1.21.11/develop/key-mappings.md
+++ b/versions/1.21.11/develop/key-mappings.md
@@ -32,11 +32,11 @@ our key mapping at the same time.
 
 ::: info
 
-Note that the names of the key tokens (`GLFW.GLFW_KEY_*`) assume
+Note that the names of the key tokens (`InputConstants.KEY_*`) assume
 a [standard US layout](https://upload.wikimedia.org/wikipedia/commons/d/da/KB_United_States.svg).
 
 This means that if you're using an AZERTY layout, pressing on <kbd>A</kbd> would yield
-`GLFW.GLFW_KEY_Q`.
+`InputConstants.KEY_Q`.
 
 :::
 

--- a/versions/1.21.11/translated/de_de/develop/key-mappings.md
+++ b/versions/1.21.11/translated/de_de/develop/key-mappings.md
@@ -28,10 +28,10 @@ gleichzeitig unsere Tastenbelegung zu registrieren.
 
 ::: info
 
-Beachte, dass die Namen der Tastentoken (`GLFW.GLFW_KEY_*`) von einem
+Beachte, dass die Namen der Tastentoken (`InputConstants.KEY_*`) von einem
 [Standard-US-Layout](https://upload.wikimedia.org/wikipedia/commons/d/da/KB_United_States.svg) ausgehen.
 
-Das bedeutet, dass bei Verwendung eines AZERTY-Layouts das Drücken von <kbd>A</kbd> zu `GLFW.GLFW_KEY_Q` führt.
+Das bedeutet, dass bei Verwendung eines AZERTY-Layouts das Drücken von <kbd>A</kbd> zu `InputConstants.KEY_Q` führt.
 
 :::
 

--- a/versions/1.21.11/translated/uk_ua/develop/key-mappings.md
+++ b/versions/1.21.11/translated/uk_ua/develop/key-mappings.md
@@ -29,10 +29,10 @@ Minecraft обробляє введення користувачами з пер
 
 ::: info
 
-Зауважте, що назви маркерів ключів (`GLFW.GLFW_KEY_*`) припускаються [стандартний макет США](https://upload.wikimedia.org/wikipedia/commons/d/da/KB_United_States.svg).
+Зауважте, що назви маркерів ключів (`InputConstants.KEY_*`) припускаються [стандартний макет США](https://upload.wikimedia.org/wikipedia/commons/d/da/KB_United_States.svg).
 
 Це означає, що якщо ви використовуєте макет AZERTY, натискання <kbd>A</kbd> призведе до
-`GLFW.GLFW_KEY_Q`.
+`InputConstants.KEY_Q`.
 
 :::
 

--- a/versions/1.21.11/translated/zh_cn/develop/key-mappings.md
+++ b/versions/1.21.11/translated/zh_cn/develop/key-mappings.md
@@ -27,9 +27,9 @@ Minecraft 使用按键映射来处理来自像键盘、鼠标之类的外围设�
 
 ::: info
 
-注意按键的名称（`GLFW.GLFW_KEY_*`）会假定我们使用的是[标准美式布局](https://upload.wikimedia.org/wikipedia/commons/d/da/KB_United_States.svg)。
+注意按键的名称（`InputConstants.KEY_*`）会假定我们使用的是[标准美式布局](https://upload.wikimedia.org/wikipedia/commons/d/da/KB_United_States.svg)。
 
-这意味着如果使用的是 AZERTY 布局，按下 <kbd>A</kbd> 可能会产生 `GLFW.GLFW_KEY_Q`。
+这意味着如果使用的是 AZERTY 布局，按下 <kbd>A</kbd> 可能会产生 `InputConstants.KEY_Q`。
 
 :::
 

--- a/versions/26.1.2/develop/key-mappings.md
+++ b/versions/26.1.2/develop/key-mappings.md
@@ -32,11 +32,11 @@ our key mapping at the same time.
 
 ::: info
 
-Note that the names of the key tokens (`GLFW.GLFW_KEY_*`) assume
+Note that the names of the key tokens (`InputConstants.KEY_*`) assume
 a [standard US layout](https://upload.wikimedia.org/wikipedia/commons/d/da/KB_United_States.svg).
 
 This means that if you're using an AZERTY layout, pressing on <kbd>A</kbd> would yield
-`GLFW.GLFW_KEY_Q`.
+`InputConstants.KEY_Q`.
 
 :::
 

--- a/versions/26.1.2/translated/de_de/develop/key-mappings.md
+++ b/versions/26.1.2/translated/de_de/develop/key-mappings.md
@@ -30,10 +30,10 @@ gleichzeitig unsere Tastenbelegung zu registrieren.
 
 ::: info
 
-Beachte, dass die Namen der Tastentoken (`GLFW.GLFW_KEY_*`) von einem
+Beachte, dass die Namen der Tastentoken (`InputConstants.KEY_*`) von einem
 [Standard-US-Layout](https://upload.wikimedia.org/wikipedia/commons/d/da/KB_United_States.svg) ausgehen.
 
-Das bedeutet, dass bei Verwendung eines AZERTY-Layouts das Drücken von <kbd>A</kbd> zu `GLFW.GLFW_KEY_Q` führt.
+Das bedeutet, dass bei Verwendung eines AZERTY-Layouts das Drücken von <kbd>A</kbd> zu `InputConstants.KEY_Q` führt.
 
 :::
 

--- a/versions/26.1.2/translated/ru_ru/develop/key-mappings.md
+++ b/versions/26.1.2/translated/ru_ru/develop/key-mappings.md
@@ -29,9 +29,9 @@ Minecraft обрабатывает ввод пользователя с пери
 
 ::: info
 
-Обратите внимание, что названия токенов клавиш (`GLFW.GLFW_KEY_*`) подразумевают [стандартную раскладку США](https://upload.wikimedia.org/wikipedia/commons/d/da/KB_United_States.svg).
+Обратите внимание, что названия токенов клавиш (`InputConstants.KEY_*`) подразумевают [стандартную раскладку США](https://upload.wikimedia.org/wikipedia/commons/d/da/KB_United_States.svg).
 
-Это означает, что если вы используете раскладку AZERTY, нажатие на клавишу <kbd>A</kbd> вернет значение `GLFW.GLFW_KEY_Q`.
+Это означает, что если вы используете раскладку AZERTY, нажатие на клавишу <kbd>A</kbd> вернет значение `InputConstants.KEY_Q`.
 
 :::
 

--- a/versions/26.1.2/translated/uk_ua/develop/key-mappings.md
+++ b/versions/26.1.2/translated/uk_ua/develop/key-mappings.md
@@ -29,10 +29,10 @@ Minecraft обробляє введення користувачами з пер
 
 ::: info
 
-Зауважте, що назви маркерів ключів (`GLFW.GLFW_KEY_*`) припускаються [стандартний макет США](https://upload.wikimedia.org/wikipedia/commons/d/da/KB_United_States.svg).
+Зауважте, що назви маркерів ключів (`InputConstants.KEY_*`) припускаються [стандартний макет США](https://upload.wikimedia.org/wikipedia/commons/d/da/KB_United_States.svg).
 
 Це означає, що якщо ви використовуєте макет AZERTY, натискання <kbd>A</kbd> призведе до
-`GLFW.GLFW_KEY_Q`.
+`InputConstants.KEY_Q`.
 
 :::
 

--- a/versions/26.1.2/translated/zh_cn/develop/key-mappings.md
+++ b/versions/26.1.2/translated/zh_cn/develop/key-mappings.md
@@ -29,9 +29,9 @@ Minecraft 使用按键映射来处理来自像键盘、鼠标之类的外围设�
 
 ::: info
 
-注意按键的名称（`GLFW.GLFW_KEY_*`）会假定我们使用的是[标准美式布局](https://upload.wikimedia.org/wikipedia/commons/d/da/KB_United_States.svg)。
+注意按键的名称（`InputConstants.KEY_*`）会假定我们使用的是[标准美式布局](https://upload.wikimedia.org/wikipedia/commons/d/da/KB_United_States.svg)。
 
-这意味着如果使用的是 AZERTY 布局，按下 <kbd>A</kbd> 可能会产生 `GLFW.GLFW_KEY_Q`。
+这意味着如果使用的是 AZERTY 布局，按下 <kbd>A</kbd> 可能会产生 `InputConstants.KEY_Q`。
 
 :::
 


### PR DESCRIPTION
26.3 has removed GLFW, which means any mods using it for key mappings will have to switch over to Mojang's own `InputConstants`. As these input constants have existed at least as far back as the `KeyMapping` page, I see no reason why we can't recommend making use of them now, saving time porting.