### PR TITLE
Document mixin compat level handling

### DIFF
--- a/develop/loader/fabric-mod-json.md
+++ b/develop/loader/fabric-mod-json.md
@@ -227,9 +227,8 @@ The following keys will accept a dictionary of dependencies. For more details on
 Fabric Loader will examine a mod's dependency on Loader to control changes to mixin behavior that
 may be incompatible with earlier or newer versions of Loader.
 
-The mods declared `depends` and `breaks` clauses in the [fabric.mod.json](../loader/fabric-mod-json#dependency-resolution) targeting `fabricloader`
-or `fabric-loader` (the former is preferred). The minimum compatible Loader version will determine
-the compatibility level.
+The mods declared `depends` and `breaks` clauses in the [fabric.mod.json](../loader/fabric-mod-json#dependency-resolution) targeting `fabricloader`. 
+The minimum compatible Loader version will determine the compatibility level.
 
 If no Loader dependency is specified, the minimum compatibility level (equivalent to Fabric Loader 0.9.2) is used.
 

--- a/develop/loader/fabric-mod-json.md
+++ b/develop/loader/fabric-mod-json.md
@@ -227,7 +227,7 @@ The following keys will accept a dictionary of dependencies. For more details on
 Fabric Loader will examine a mod's dependency on Loader to control changes to mixin behavior that
 may be incompatible with earlier or newer versions of Loader.
 
-The mods declared `depends` and `breaks` clauses in the [fabric.mod.json](../loader/fabric-mod-json#dependency-resolution) targeting `fabricloader`. 
+The mods declared `depends` and `breaks` clauses in the [fabric.mod.json](../loader/fabric-mod-json#dependency-resolution) targeting `fabricloader`.
 The minimum compatible Loader version will determine the compatibility level.
 
 If no Loader dependency is specified, the minimum compatibility level (equivalent to Fabric Loader 0.9.2) is used.

--- a/develop/loader/fabric-mod-json.md
+++ b/develop/loader/fabric-mod-json.md
@@ -231,7 +231,7 @@ The mods declared `depends` and `breaks` clauses in the [fabric.mod.json](../loa
 or `fabric-loader` (the former is preferred). The minimum compatible Loader version will determine
 the compatibility level.
 
-If no Loader dependency is specified, the minimum compatability level (equivalent to Fabric Loader 0.9.2) is used.
+If no Loader dependency is specified, the minimum compatibility level (equivalent to Fabric Loader 0.9.2) is used.
 
 **Note:** It is strongly encouraged to declare the minimum Fabric Loader dependency a mod is tested
 against!
@@ -244,7 +244,7 @@ For example, to enable enum extensions via mixin, at least this version of Loade
 }
 ```
 
-See the [compatability level documentation](../mixins/bytecode#compat-level) if any changes are applicable to your mod.
+See the [compatibility level documentation](../mixins/bytecode#compat-level) if any changes are applicable to your mod.
 
 :::
 

--- a/develop/loader/fabric-mod-json.md
+++ b/develop/loader/fabric-mod-json.md
@@ -222,6 +222,29 @@ The following keys will accept a dictionary of dependencies. For more details on
 - **`breaks`**: For mods whose together with yours might cause a game crash. **If any are present, Fabric Loader will trigger a crash**.
 - **`conflicts`**: For mods whose together with yours cause some kind of bugs, etc. For each conflicting mod present, Fabric Loader will log a warning.
 
+::: warning Dependencies Involving Fabric Loader
+
+Fabric Loader will examine a mod's dependency on Loader to control changes to mixin behavior that
+may be incompatible with earlier or newer versions of Loader.
+
+See the [compatability level documentation](../mixins/bytecode#compat-level) for more information
+on how Loader dependency is handled and if any changes are applicable to your mod.
+
+If no Loader dependency is declared, Loader will use the compatibility equivalent to version `0.9.2`.
+
+**Note:** It is strongly encouraged to declare the minimum Fabric Loader dependency a mod is tested
+against!
+
+For example, to enable enum extensions via mixin, at least this version of Loader is required:
+
+```json
+"depends": {
+   "fabricloader": ">=0.19.0"
+}
+```
+
+:::
+
 ### Semantic Versioning {#semantic-versioning}
 
 The key of each entry is the mod ID of the dependency.

--- a/develop/loader/fabric-mod-json.md
+++ b/develop/loader/fabric-mod-json.md
@@ -227,10 +227,11 @@ The following keys will accept a dictionary of dependencies. For more details on
 Fabric Loader will examine a mod's dependency on Loader to control changes to mixin behavior that
 may be incompatible with earlier or newer versions of Loader.
 
-See the [compatability level documentation](../mixins/bytecode#compat-level) for more information
-on how Loader dependency is handled and if any changes are applicable to your mod.
+The mods declared `depends` and `breaks` clauses in the [fabric.mod.json](../loader/fabric-mod-json#dependency-resolution) targeting `fabricloader`
+or `fabric-loader` (the former is preferred). The minimum compatible Loader version will determine
+the compatibility level.
 
-If no Loader dependency is declared, Loader will use the compatibility equivalent to version `0.9.2`.
+If no Loader dependency is specified, the minimum compatability level (equivalent to Fabric Loader 0.9.2) is used.
 
 **Note:** It is strongly encouraged to declare the minimum Fabric Loader dependency a mod is tested
 against!
@@ -242,6 +243,8 @@ For example, to enable enum extensions via mixin, at least this version of Loade
    "fabricloader": ">=0.19.0"
 }
 ```
+
+See the [compatability level documentation](../mixins/bytecode#compat-level) if any changes are applicable to your mod.
 
 :::
 

--- a/develop/mixins/bytecode.md
+++ b/develop/mixins/bytecode.md
@@ -604,27 +604,19 @@ Example:
 - Changes to local variable handling to better preserve local variables at the target location where previously they may have been incorrectly removed from Mixin's view
   - For more details, see [this mixin issue](https://github.com/SpongePowered/Mixin/issues/508).
 
-***
-
 #### Compatibility Level 0.14.0 (Fabric Loader 0.14.0, Mixin 0.8.6) {#compat-level-0140}
 
 - Gates a change to the filtering of `NEW` descriptors pursuant to a Mixin [bugfix](https://github.com/SpongePowered/Mixin/issues/515) allowing the constructor descriptor to be used to target an invocation.
 
-***
-
 #### Compatibility Level 0.16.5 (Fabric Loader 0.16.5, Mixin 0.8.7) {#compat-level-087}
 
 - `SHIFT` is now respected during injections.
-
-***
 
 #### Compatibility Level 0.17.0 (Fabric Loader 0.17.0, Mixin 0.8.7) {#compat-level-0170}
 
 - Local variable capture of method parameters
   - If possible, allow capturing by using the parameter's actual name
   - Otherwise, fallback to parameters named `arg<paramIndex>`, which previously was only the case when `argsOnly = false`. When `argsOnly` was `true`, they were named `arg<lvIndex>`
-
-***
 
 #### Compatibility Level 0.17.1 (Fabric Loader 0.17.1, Mixin 0.8.7) {#compat-level-0171}
 

--- a/develop/mixins/bytecode.md
+++ b/develop/mixins/bytecode.md
@@ -580,7 +580,7 @@ Here, the `name` parameter is being passed as a parameter into the lambda. Notic
 
 Mixin is a complicated and evolving tool that, for the sake of fixing bugs, sometimes changes behavior in such a way that working mods can break with a loader update.
 Starting with Fabric Loader 0.12.3 (a beta version, recommended to use 0.12.5), Loader is able to change mixin behavior on a per-mod basis, allowing old mods to continue working with
-the old behavior, and new mods to have access to any fixes they need. This is done by selecting the earliest Loader version compatible with a given mod, and then choosing the appropriate compat level.
+the old behavior, and new mods to have access to any fixes they need. New features may also be gated behind this block. This is done by selecting the earliest Loader version compatible with a given mod, and then choosing the appropriate compat level.
 
 Fabric Loader version compatibility is based on the mods declared `depends` and `breaks` clauses in the [fabric.mod.json](../loader/fabric-mod-json#dependency-resolution) targeting `fabricloader` or `fabric-loader` (the former is preferred). It is strongly encouraged to declare the
 minimum Fabric Loader dependency a mod is tested against, or if new functionality is desired, a newer loader version.

--- a/develop/mixins/bytecode.md
+++ b/develop/mixins/bytecode.md
@@ -582,7 +582,7 @@ Mixin is a complicated and evolving tool that, for the sake of fixing bugs, some
 Starting with Fabric Loader 0.12.3 (a beta version, recommended to use 0.12.5), Loader is able to change mixin behavior on a per-mod basis, allowing old mods to continue working with
 the old behavior, and new mods to have access to any fixes they need. This is done by selecting the earliest Loader version compatible with a given mod, and then choosing the appropriate compat level.
 
-Fabric Loader version compatibility is based on the mods declared `depends` and `breaks` clauses in the [fabric.mod.json](../loader/fabric-mod-json.md#dependency-resolution) targeting `fabricloader` or `fabric-loader` (the former is preferred). It is strongly encouraged to declare the
+Fabric Loader version compatibility is based on the mods declared `depends` and `breaks` clauses in the [fabric.mod.json](../loader/fabric-mod-json#dependency-resolution) targeting `fabricloader` or `fabric-loader` (the former is preferred). It is strongly encouraged to declare the
 minimum Fabric Loader dependency a mod is tested against, or if new functionality is desired, a newer loader version.
 
 If no Loader dependency is specified, the minimum compatability level (equivalent to Fabric Loader 0.9.2) is used.
@@ -595,30 +595,30 @@ Example:
 }
 ```
 
-### Compatibility Level Determination
+### Compatibility Level Determination {#compat-level}
 
-### Changes
+### Changes {#compat-changes}
 
-#### Compatibility Level 0.10.0 (Fabric Loader 0.10.0, Mixin 0.8.4)
+#### Compatibility Level 0.10.0 (Fabric Loader 0.10.0, Mixin 0.8.4) {#compat-level-0100}
 
 - Changes to local variable handling to better preserve local variables at the target location where previously they may have been incorrectly removed from Mixin's view
   - For more details, see [this mixin issue](https://github.com/SpongePowered/Mixin/issues/508).
 
 ---
 
-#### Compatibility Level 0.14.0 (Fabric Loader 0.14.0, Mixin 0.8.6)
+#### Compatibility Level 0.14.0 (Fabric Loader 0.14.0, Mixin 0.8.6) {#compat-level-0140}
 
 - Gates a change to the filtering of `NEW` descriptors pursuant to a Mixin [bugfix](https://github.com/SpongePowered/Mixin/issues/515) allowing the constructor descriptor to be used to target an invocation.
 
 ---
 
-#### Compatibility Level 0.16.5 (Fabric Loader 0.16.5, Mixin 0.8.7)
+#### Compatibility Level 0.16.5 (Fabric Loader 0.16.5, Mixin 0.8.7) {#compat-level-087}
 
 - `SHIFT` is now respected during injections.
 
 ---
 
-#### Compatibility Level 0.17.0 (Fabric Loader 0.17.0, Mixin 0.8.7)
+#### Compatibility Level 0.17.0 (Fabric Loader 0.17.0, Mixin 0.8.7) {#compat-level-0170}
 
 - Local variable capture of method parameters
   - If possible, allow capturing by using the parameter's actual name
@@ -626,7 +626,7 @@ Example:
 
 ---
 
-#### Compatibility Level 0.17.1 (Fabric Loader 0.17.1, Mixin 0.8.7)
+#### Compatibility Level 0.17.1 (Fabric Loader 0.17.1, Mixin 0.8.7) {#compat-level-0171}
 
 - Introduces new initializer merging and targeting behavior for class initializers (`<clinit>`)
   - Preserve `try-catch` blocks, local variables, and line numbers

--- a/develop/mixins/bytecode.md
+++ b/develop/mixins/bytecode.md
@@ -576,7 +576,7 @@ static lambda$hello$1 (Ljava/lang/String;)V
 
 Here, the `name` parameter is being passed as a parameter into the lambda. Notice also how string concatenation is implemented with `invokedynamic`.
 
-## Differences in Mixin Bytecode Handling
+## Differences in Mixin Bytecode Handling {#compat-level}
 
 Mixin is a complicated and evolving tool that, for the sake of fixing bugs, sometimes changes behavior in such a way that working mods can break with a loader update.
 Starting with Fabric Loader 0.12.3 (a beta version, recommended to use 0.12.5), Loader is able to change mixin behavior on a per-mod basis, allowing old mods to continue working with
@@ -595,7 +595,7 @@ Example:
 }
 ```
 
-### Compatibility Level Determination {#compat-level}
+### Compatibility Level Determination {#compat-level-determination}
 
 ### Changes {#compat-changes}
 
@@ -604,19 +604,19 @@ Example:
 - Changes to local variable handling to better preserve local variables at the target location where previously they may have been incorrectly removed from Mixin's view
   - For more details, see [this mixin issue](https://github.com/SpongePowered/Mixin/issues/508).
 
----
+***
 
 #### Compatibility Level 0.14.0 (Fabric Loader 0.14.0, Mixin 0.8.6) {#compat-level-0140}
 
 - Gates a change to the filtering of `NEW` descriptors pursuant to a Mixin [bugfix](https://github.com/SpongePowered/Mixin/issues/515) allowing the constructor descriptor to be used to target an invocation.
 
----
+***
 
 #### Compatibility Level 0.16.5 (Fabric Loader 0.16.5, Mixin 0.8.7) {#compat-level-087}
 
 - `SHIFT` is now respected during injections.
 
----
+***
 
 #### Compatibility Level 0.17.0 (Fabric Loader 0.17.0, Mixin 0.8.7) {#compat-level-0170}
 
@@ -624,7 +624,7 @@ Example:
   - If possible, allow capturing by using the parameter's actual name
   - Otherwise, fallback to parameters named `arg<paramIndex>`, which previously was only the case when `argsOnly = false`. When `argsOnly` was `true`, they were named `arg<lvIndex>`
 
----
+***
 
 #### Compatibility Level 0.17.1 (Fabric Loader 0.17.1, Mixin 0.8.7) {#compat-level-0171}
 

--- a/develop/mixins/bytecode.md
+++ b/develop/mixins/bytecode.md
@@ -586,26 +586,26 @@ See [Compatibility Level Determination](../loader/fabric-mod-json#dependency-res
 
 ### Changes {#compat-changes}
 
-#### Compatibility Level 0.10.0 (Fabric Loader 0.12.0, Mixin 0.8.4) {#compat-level-0100}
+#### Compatibility Level 0.10.0 (Fabric Loader 0.12.0) {#compat-level-0100}
 
 - Changes to local variable handling to better preserve local variables at the target location where previously they may have been incorrectly removed from Mixin's view
   - For more details, see [this mixin issue](https://github.com/SpongePowered/Mixin/issues/508).
 
-#### Compatibility Level 0.14.0 (Fabric Loader 0.16.0, Mixin 0.8.6) {#compat-level-0140}
+#### Compatibility Level 0.14.0 (Fabric Loader 0.16.0) {#compat-level-0140}
 
 - Gates a change to the filtering of `NEW` descriptors pursuant to a Mixin [bugfix](https://github.com/SpongePowered/Mixin/issues/515) allowing the constructor descriptor to be used to target an invocation.
 
-#### Compatibility Level 0.16.5 (Fabric Loader 0.17.3, Mixin 0.8.7) {#compat-level-087}
+#### Compatibility Level 0.16.5 (Fabric Loader 0.17.3) {#compat-level-087}
 
 - `SHIFT` is now respected during injections.
 
-#### Compatibility Level 0.17.0 (Fabric Loader 0.18.4, Mixin 0.8.7) {#compat-level-0170}
+#### Compatibility Level 0.17.0 (Fabric Loader 0.18.4) {#compat-level-0170}
 
 - Local variable capture of method parameters
   - If possible, allow capturing by using the parameter's actual name
   - Otherwise, fallback to parameters named `arg<paramIndex>`, which previously was only the case when `argsOnly = false`. When `argsOnly` was `true`, they were named `arg<lvIndex>`
 
-#### Compatibility Level 0.17.1 (Fabric Loader 0.19.0, Mixin 0.8.7) {#compat-level-0171}
+#### Compatibility Level 0.17.1 (Fabric Loader 0.19.0) {#compat-level-0171}
 
 - Introduces new initializer merging and targeting behavior for class initializers (`<clinit>`)
   - Preserve `try-catch` blocks, local variables, and line numbers

--- a/develop/mixins/bytecode.md
+++ b/develop/mixins/bytecode.md
@@ -599,28 +599,29 @@ Example:
 
 ### Changes {#compat-changes}
 
-#### Compatibility Level 0.10.0 (Fabric Loader 0.10.0, Mixin 0.8.4) {#compat-level-0100}
+#### Compatibility Level 0.10.0 (Fabric Loader 0.12.0, Mixin 0.8.4) {#compat-level-0100}
 
 - Changes to local variable handling to better preserve local variables at the target location where previously they may have been incorrectly removed from Mixin's view
   - For more details, see [this mixin issue](https://github.com/SpongePowered/Mixin/issues/508).
 
-#### Compatibility Level 0.14.0 (Fabric Loader 0.14.0, Mixin 0.8.6) {#compat-level-0140}
+#### Compatibility Level 0.14.0 (Fabric Loader 0.16.0, Mixin 0.8.6) {#compat-level-0140}
 
 - Gates a change to the filtering of `NEW` descriptors pursuant to a Mixin [bugfix](https://github.com/SpongePowered/Mixin/issues/515) allowing the constructor descriptor to be used to target an invocation.
 
-#### Compatibility Level 0.16.5 (Fabric Loader 0.16.5, Mixin 0.8.7) {#compat-level-087}
+#### Compatibility Level 0.16.5 (Fabric Loader 0.17.3, Mixin 0.8.7) {#compat-level-087}
 
 - `SHIFT` is now respected during injections.
 
-#### Compatibility Level 0.17.0 (Fabric Loader 0.17.0, Mixin 0.8.7) {#compat-level-0170}
+#### Compatibility Level 0.17.0 (Fabric Loader 0.18.4, Mixin 0.8.7) {#compat-level-0170}
 
 - Local variable capture of method parameters
   - If possible, allow capturing by using the parameter's actual name
   - Otherwise, fallback to parameters named `arg<paramIndex>`, which previously was only the case when `argsOnly = false`. When `argsOnly` was `true`, they were named `arg<lvIndex>`
 
-#### Compatibility Level 0.17.1 (Fabric Loader 0.17.1, Mixin 0.8.7) {#compat-level-0171}
+#### Compatibility Level 0.17.1 (Fabric Loader 0.19.0, Mixin 0.8.7) {#compat-level-0171}
 
 - Introduces new initializer merging and targeting behavior for class initializers (`<clinit>`)
   - Preserve `try-catch` blocks, local variables, and line numbers
   - Can no longer be skipped by an early return in the target or another mixin
   - Can no longer target mixin-added initializers
+- Support for Mixin-based [enum extension](../class-tweakers/enum-extension)

--- a/develop/mixins/bytecode.md
+++ b/develop/mixins/bytecode.md
@@ -2,6 +2,7 @@
 title: Java Bytecode
 description: Learn about Java bytecode so that you can write mixins effectively.
 authors:
+  - Deximus-Maximus
   - Earthcomputer
   - its-miroma
   - Kilip1000
@@ -574,3 +575,59 @@ static lambda$hello$1 (Ljava/lang/String;)V
 :::
 
 Here, the `name` parameter is being passed as a parameter into the lambda. Notice also how string concatenation is implemented with `invokedynamic`.
+
+## Differences in Mixin Bytecode Handling
+
+Mixin is a complicated and evolving tool that, for the sake of fixing bugs, sometimes changes behavior in such a way that working mods can break with a loader update.
+Starting with Fabric Loader 0.12.3 (a beta version, recommended to use 0.12.5), Loader is able to change mixin behavior on a per-mod basis, allowing old mods to continue working with
+the old behavior, and new mods to have access to any fixes they need. This is done by selecting the earliest Loader version compatible with a given mod, and then choosing the appropriate compat level.
+
+Fabric Loader version compatibility is based on the mods declared `depends` and `breaks` clauses in the [fabric.mod.json](../loader/fabric-mod-json.md#dependency-resolution) targeting `fabricloader` or `fabric-loader` (the former is preferred). It is strongly encouraged to declare the
+minimum Fabric Loader dependency a mod is tested against, or if new functionality is desired, a newer loader version.
+
+If no Loader dependency is specified, the minimum compatability level (equivalent to Fabric Loader 0.9.2) is used.
+
+Example:
+```json
+"depends": {
+   "fabricloader": ">=0.14.0"
+}
+```
+
+### Compatibility Level Determination
+
+### Changes
+
+#### Compatibility Level 0.10.0 (Fabric Loader 0.10.0, Mixin 0.8.4)
+
+- Changes to local variable handling to better preserve local variables at the target location where previously they may have been incorrectly removed from Mixin's view
+  - For more details, see [this mixin issue](https://github.com/SpongePowered/Mixin/issues/508).
+
+---
+
+#### Compatibility Level 0.14.0 (Fabric Loader 0.14.0, Mixin 0.8.6)
+
+- Gates a change to the filtering of `NEW` descriptors pursuant to a Mixin [bugfix](https://github.com/SpongePowered/Mixin/issues/515) allowing the constructor descriptor to be used to target an invocation.
+
+---
+
+#### Compatibility Level 0.16.5 (Fabric Loader 0.16.5, Mixin 0.8.7)
+
+- `SHIFT` is now respected during injections.
+
+---
+
+#### Compatibility Level 0.17.0 (Fabric Loader 0.17.0, Mixin 0.8.7)
+
+- Local variable capture of method parameters
+  - If possible, allow capturing by using the parameter's actual name
+  - Otherwise, fallback to parameters named `arg<paramIndex>`, which previously was only the case when `argsOnly = false`. When `argsOnly`  was `true`, they were named `arg<lvIndex>`
+
+---
+
+#### Compatibility Level 0.17.1 (Fabric Loader 0.17.1, Mixin 0.8.7)
+
+- Introduces new initializer merging and targeting behavior for class initializers (`<clinit>`)
+  - Preserve `try-catch` blocks, local variables, and line numbers
+  - Can no longer be skipped by an early return in the target or another mixin
+  - Can no longer target mixin-added initializers

--- a/develop/mixins/bytecode.md
+++ b/develop/mixins/bytecode.md
@@ -582,20 +582,7 @@ Mixin is a complicated and evolving tool that, for the sake of fixing bugs, some
 Starting with Fabric Loader 0.12.3 (a beta version, recommended to use 0.12.5), Loader is able to change mixin behavior on a per-mod basis, allowing old mods to continue working with
 the old behavior, and new mods to have access to any fixes they need. New features may also be gated behind this block. This is done by selecting the earliest Loader version compatible with a given mod, and then choosing the appropriate compat level.
 
-Fabric Loader version compatibility is based on the mods declared `depends` and `breaks` clauses in the [fabric.mod.json](../loader/fabric-mod-json#dependency-resolution) targeting `fabricloader` or `fabric-loader` (the former is preferred). It is strongly encouraged to declare the
-minimum Fabric Loader dependency a mod is tested against, or if new functionality is desired, a newer loader version.
-
-If no Loader dependency is specified, the minimum compatability level (equivalent to Fabric Loader 0.9.2) is used.
-
-Example:
-
-```json
-"depends": {
-   "fabricloader": ">=0.14.0"
-}
-```
-
-### Compatibility Level Determination {#compat-level-determination}
+See [Compatibility Level Determination](../loader/fabric-mod-json#dependency-resolution) for more details on which compatibility level is selected.
 
 ### Changes {#compat-changes}
 

--- a/develop/mixins/bytecode.md
+++ b/develop/mixins/bytecode.md
@@ -588,6 +588,7 @@ minimum Fabric Loader dependency a mod is tested against, or if new functionalit
 If no Loader dependency is specified, the minimum compatability level (equivalent to Fabric Loader 0.9.2) is used.
 
 Example:
+
 ```json
 "depends": {
    "fabricloader": ">=0.14.0"
@@ -621,7 +622,7 @@ Example:
 
 - Local variable capture of method parameters
   - If possible, allow capturing by using the parameter's actual name
-  - Otherwise, fallback to parameters named `arg<paramIndex>`, which previously was only the case when `argsOnly = false`. When `argsOnly`  was `true`, they were named `arg<lvIndex>`
+  - Otherwise, fallback to parameters named `arg<paramIndex>`, which previously was only the case when `argsOnly = false`. When `argsOnly` was `true`, they were named `arg<lvIndex>`
 
 ---
 


### PR DESCRIPTION
Add documentation for mixin compat level, which is based on the mod's floader version dependency. The bytecode section seemed to be the most relevant existing page for this, and I don't think the list is long enough to warrant its own page yet.