### PR TITLE
Prevent flicker with FullscreenCode on firefox

### DIFF
--- a/.vitepress/theme/components/FullscreenCode.vue
+++ b/.vitepress/theme/components/FullscreenCode.vue
@@ -19,7 +19,7 @@ const isClosing = ref(false);
 const isWrapped = ref(false);
 const isCopied = ref(false);
 
-const loadCodeBlock = (originalCodeBlock: HTMLDivElement) => {
+const loadCodeBlock = async (originalCodeBlock: HTMLDivElement) => {
   if (!dialog.value) return;
 
   originalCopyButton.value =
@@ -37,10 +37,11 @@ const loadCodeBlock = (originalCodeBlock: HTMLDivElement) => {
   if (prefersReducedMotion.value === "reduce" || !document.startViewTransition)
     return onViewTransition();
 
-  document.startViewTransition(onViewTransition);
+  let viewTransition = document.startViewTransition(onViewTransition);
+  await viewTransition.ready;
 };
 
-const handleEnterFullscreen = (originalCodeBlock: HTMLDivElement) => {
+const handleEnterFullscreen = async (originalCodeBlock: HTMLDivElement) => {
   if (!dialog.value) return;
 
   const originalCodeGroup = originalCodeBlock.closest<HTMLDivElement>("div.vp-code-group");
@@ -53,7 +54,7 @@ const handleEnterFullscreen = (originalCodeBlock: HTMLDivElement) => {
     ];
   }
 
-  loadCodeBlock(originalCodeBlock);
+  await loadCodeBlock(originalCodeBlock);
   dialog.value.showModal();
   if (document.activeElement instanceof HTMLElement) document.activeElement.blur();
 };

--- a/.vitepress/theme/components/FullscreenCode.vue
+++ b/.vitepress/theme/components/FullscreenCode.vue
@@ -37,8 +37,7 @@ const loadCodeBlock = async (originalCodeBlock: HTMLDivElement) => {
   if (prefersReducedMotion.value === "reduce" || !document.startViewTransition)
     return onViewTransition();
 
-  let viewTransition = document.startViewTransition(onViewTransition);
-  await viewTransition.ready;
+  await document.startViewTransition(onViewTransition).ready;
 };
 
 const handleEnterFullscreen = async (originalCodeBlock: HTMLDivElement) => {


### PR DESCRIPTION
For some reason Firefox requires the `ViewTransition` to be ready before starting the animation

[Screencast_20260804_200833.webm](https://github.com/user-attachments/assets/c246f819-1e73-4595-b080-17596bebeda4)

tbh I am not even sure why a `ViewTransition` is being used, I can't see a difference (also tested in chrome).
But I am probably just missing something