### PR TITLE
Fix onTake bug in code for Workstations

### DIFF
--- a/reference/26.1.2/src/main/java/com/example/docs/menu/custom/SuperiorUpgradingMenu.java
+++ b/reference/26.1.2/src/main/java/com/example/docs/menu/custom/SuperiorUpgradingMenu.java
@@ -70,7 +70,7 @@ public class SuperiorUpgradingMenu extends UpgradingMenu {
 			return ItemStack.EMPTY;
 		}
 
-		slot.onTake(player, stack);
+		slot.onTake(player, clicked);
 
 		if (slotIndex == RESULT_SLOT) {
 			player.drop(stack, false);

--- a/reference/latest/src/main/java/com/example/docs/menu/custom/SuperiorUpgradingMenu.java
+++ b/reference/latest/src/main/java/com/example/docs/menu/custom/SuperiorUpgradingMenu.java
@@ -70,7 +70,7 @@ public class SuperiorUpgradingMenu extends UpgradingMenu {
 			return ItemStack.EMPTY;
 		}
 
-		slot.onTake(player, stack);
+		slot.onTake(player, clicked);
 
 		if (slotIndex == RESULT_SLOT) {
 			player.drop(stack, false);


### PR DESCRIPTION
This PR fixes an `onTake` call in Workstations, so that it's no longer called with an empty stack.

Original code is based on Minecraft's source code, which has a similar bug of which the result is reported as [MC-267545](https://bugs.mojang.com/browse/MC/issues/MC-267545). On that issue, some commenter suggests another solution, but I think it would require much more changes than this PR makes and it's better to get it a bit more right quickly.

On Fabricord, I discussed this with the code's original author (SkyNotTheLimit) and they agreed.